### PR TITLE
Use the default clang on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,5 @@ sudo: false
 language: node_js
 node_js:
   - "node"
-compiler: clang-3.6
 before_install:
   - git submodule update --init --recursive
-env:
-  - CXX=clang-3.6
-
-addons:
-  apt:
-    sources:
-      - llvm-toolchain-precise-3.6
-      - ubuntu-toolchain-r-test
-    packages:
-      - clang-3.6


### PR DESCRIPTION
It seems that Travis is using Trusty by default now. A new-enough version of clang might already be installed.