### PR TITLE
Add SyntaxNode.descendantsOfType method

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ Object.defineProperty(Tree.prototype, 'rootNode', {
   }
 })
 
+Tree.prototype.walk = function () {
+  return this.rootNode.walk()
+}
+
 class SyntaxNode {
   constructor(tree) {
     this.tree = tree;
@@ -223,6 +227,11 @@ class SyntaxNode {
       NodeMethods.descendantForPosition(this.tree, start, start);
     }
     return unmarshalNode(this.tree);
+  }
+
+  walk () {
+    marshalNode(this);
+    return NodeMethods.walk(this.tree);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const {rootNode} = Tree.prototype;
 
 Object.defineProperty(Tree.prototype, 'rootNode', {
   get() {
-    if (!this.nodes) this.nodes = {};
+    if (!this._nodes) this._nodes = {};
     rootNode.call(this);
     return unmarshalNode(this);
   }
@@ -325,20 +325,19 @@ Object.defineProperty(TreeCursor.prototype, 'endPosition', {
 
 const {pointTransferArray} = binding;
 
+const NODE_FIELD_COUNT = 6;
+
 function unmarshalNode(tree, offset = 0) {
   const {nodeTransferArray} = binding;
   const key = `${nodeTransferArray[offset]}${nodeTransferArray[offset + 1]}`
   if (key === '00') return null;
-  let result = tree.nodes[key];
+  let result = tree._nodes[key];
   if (!result) {
     result = new SyntaxNode(tree);
-    result._0 = nodeTransferArray[offset];
-    result._1 = nodeTransferArray[offset + 1];
-    result._2 = nodeTransferArray[offset + 2];
-    result._3 = nodeTransferArray[offset + 3];
-    result._4 = nodeTransferArray[offset + 4];
-    result._5 = nodeTransferArray[offset + 5];
-    tree.nodes[key] = result;
+    tree._nodes[key] = result;
+  }
+  for (let i = 0; i < NODE_FIELD_COUNT; i++) {
+    result[i] = nodeTransferArray[offset + i];
   }
   return result;
 }
@@ -355,12 +354,9 @@ function unmarshalNodes(tree, count) {
 
 function marshalNode(node) {
   const {nodeTransferArray} = binding;
-  nodeTransferArray[0] = node._0;
-  nodeTransferArray[1] = node._1;
-  nodeTransferArray[2] = node._2;
-  nodeTransferArray[3] = node._3;
-  nodeTransferArray[4] = node._4;
-  nodeTransferArray[5] = node._5;
+  for (let i = 0; i < NODE_FIELD_COUNT; i++) {
+    nodeTransferArray[i] = node[i];
+  }
 }
 
 function unmarshalPoint() {

--- a/index.js
+++ b/index.js
@@ -199,6 +199,12 @@ class SyntaxNode {
     return unmarshalNode(this.tree);
   }
 
+  descendantsOfType(type, start, end) {
+    marshalNode(this);
+    const count = NodeMethods.descendantsOfType(this.tree, type, start, end);
+    return unmarshalNodes(this.tree, count);
+  }
+
   namedDescendantForPosition(start, end) {
     marshalNode(this);
     if (end != null) {
@@ -308,26 +314,38 @@ Object.defineProperty(TreeCursor.prototype, 'endPosition', {
   }
 });
 
-const {pointTransferArray, nodeTransferArray} = binding;
+const {pointTransferArray} = binding;
 
-function unmarshalNode(tree) {
-  const key = `${nodeTransferArray[0]}${nodeTransferArray[1]}`
+function unmarshalNode(tree, offset = 0) {
+  const {nodeTransferArray} = binding;
+  const key = `${nodeTransferArray[offset]}${nodeTransferArray[offset + 1]}`
   if (key === '00') return null;
   let result = tree.nodes[key];
   if (!result) {
     result = new SyntaxNode(tree);
-    result._0 = nodeTransferArray[0];
-    result._1 = nodeTransferArray[1];
-    result._2 = nodeTransferArray[2];
-    result._3 = nodeTransferArray[3];
-    result._4 = nodeTransferArray[4];
-    result._5 = nodeTransferArray[5];
+    result._0 = nodeTransferArray[offset];
+    result._1 = nodeTransferArray[offset + 1];
+    result._2 = nodeTransferArray[offset + 2];
+    result._3 = nodeTransferArray[offset + 3];
+    result._4 = nodeTransferArray[offset + 4];
+    result._5 = nodeTransferArray[offset + 5];
     tree.nodes[key] = result;
   }
   return result;
 }
 
+function unmarshalNodes(tree, count) {
+  const result = new Array(count);
+  let offset = 0;
+  for (let i = 0; i < count; i++) {
+    result[i] = unmarshalNode(tree, offset)
+    offset += 6
+  }
+  return result
+}
+
 function marshalNode(node) {
+  const {nodeTransferArray} = binding;
   nodeTransferArray[0] = node._0;
   nodeTransferArray[1] = node._1;
   nodeTransferArray[2] = node._2;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter",
-  "version": "0.12.13",
+  "version": "0.12.14-0",
   "description": "Incremental parsers for node",
   "author": "Max Brunsfeld",
   "license": "MIT",

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -12,7 +12,7 @@ using namespace v8;
 
 void InitAll(Local<Object> exports) {
   InitConversions(exports);
-  Node::Init(exports);
+  node_methods::Init(exports);
   Parser::Init(exports);
   Tree::Init(exports);
   TreeCursor::Init(exports);

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -3,6 +3,7 @@
 #include <tree_sitter/runtime.h>
 #include <v8.h>
 #include "./conversions.h"
+#include <cmath>
 
 namespace node_tree_sitter {
 
@@ -100,8 +101,19 @@ Nan::Maybe<TSPoint> PointFromJS(const Local<Value> &arg) {
     return Nan::Nothing<TSPoint>();
   }
 
-  uint32_t row = static_cast<uint32_t>(js_row->Int32Value());
-  uint32_t column = static_cast<uint32_t>(js_column->Int32Value() * BYTES_PER_CHARACTER);
+  uint32_t row, column;
+  if (std::isfinite(js_row->NumberValue())) {
+    row = static_cast<uint32_t>(js_row->Int32Value());
+  } else {
+    row = UINT32_MAX;
+  }
+
+  if (std::isfinite(js_column->NumberValue())) {
+    column = static_cast<uint32_t>(js_column->Int32Value()) * BYTES_PER_CHARACTER;
+  } else {
+    column = UINT32_MAX;
+  }
+
   return Nan::Just<TSPoint>({row, column});
 }
 

--- a/src/node.h
+++ b/src/node.h
@@ -7,52 +7,12 @@
 #include <tree_sitter/runtime.h>
 
 namespace node_tree_sitter {
+namespace node_methods {
 
-class Node {
- public:
-  static void Init(v8::Local<v8::Object> exports);
-  static void MarshalNode(TSNode);
-  static void MarshalNodes(const TSNode *, uint32_t);
-  static TSNode UnmarshalNode(const v8::Local<v8::Value> &tree);
+void Init(v8::Local<v8::Object>);
+void MarshalNode(TSNode);
 
- private:
-  static void ToString(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void FirstChildForIndex(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void FirstNamedChildForIndex(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void DescendantForIndex(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void NamedDescendantForIndex(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void DescendantForPosition(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void NamedDescendantForPosition(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void IsMissing(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void HasChanges(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void HasError(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void StartPosition(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void EndPosition(const Nan::FunctionCallbackInfo<v8::Value> &);
-
-  static void Type(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void StartIndex(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void EndIndex(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void IsNamed(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void Id(const Nan::FunctionCallbackInfo<v8::Value> &);
-
-  static void Parent(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void Child(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void ChildCount(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void NamedChild(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void NamedChildCount(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void FirstChild(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void FirstNamedChild(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void LastChild(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void LastNamedChild(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void NextSibling(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void NextNamedSibling(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void PreviousSibling(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void PreviousNamedSibling(const Nan::FunctionCallbackInfo<v8::Value> &);
-
-  static void DescendantsOfType(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void Walk(const Nan::FunctionCallbackInfo<v8::Value> &);
-};
-
+}  // namespace node_methods
 }  // namespace node_tree_sitter
 
 #endif  // NODE_TREE_SITTER_NODE_H_

--- a/src/node.h
+++ b/src/node.h
@@ -50,6 +50,7 @@ class Node {
   static void PreviousNamedSibling(const Nan::FunctionCallbackInfo<v8::Value> &);
 
   static void DescendantsOfType(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void Walk(const Nan::FunctionCallbackInfo<v8::Value> &);
 };
 
 }  // namespace node_tree_sitter

--- a/src/node.h
+++ b/src/node.h
@@ -12,6 +12,7 @@ class Node {
  public:
   static void Init(v8::Local<v8::Object> exports);
   static void MarshalNode(TSNode);
+  static void MarshalNodes(const TSNode *, uint32_t);
   static TSNode UnmarshalNode(const v8::Local<v8::Value> &tree);
 
  private:
@@ -47,6 +48,8 @@ class Node {
   static void NextNamedSibling(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void PreviousSibling(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void PreviousNamedSibling(const Nan::FunctionCallbackInfo<v8::Value> &);
+
+  static void DescendantsOfType(const Nan::FunctionCallbackInfo<v8::Value> &);
 };
 
 }  // namespace node_tree_sitter

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -181,12 +181,7 @@ Parser::Parser() : parser_(ts_parser_new()), is_parsing_async_(false) {}
 Parser::~Parser() { ts_parser_delete(parser_); }
 
 static bool handle_included_ranges(TSParser *parser, Local<Value> arg) {
-  if (arg->BooleanValue()) {
-    if (!arg->IsArray()) {
-      Nan::ThrowTypeError("includedRanges must be an array");
-      return false;
-    }
-
+  if (arg->IsArray()) {
     auto js_included_ranges = Local<Array>::Cast(arg);
     vector<TSRange> included_ranges;
     for (unsigned i = 0; i < js_included_ranges->Length(); i++) {

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -377,7 +377,7 @@ void Parser::ParseTextBufferSync(const Nan::FunctionCallbackInfo<Value> &info) {
   auto snapshot = Nan::ObjectWrap::Unwrap<TextBufferSnapshotWrapper>(info[0].As<Object>());
 
   TSTree *old_tree = nullptr;
-  if (info.Length() > 1 && info[2]->BooleanValue()) {
+  if (info.Length() > 1 && info[1]->BooleanValue()) {
     const TSTree *tree = Tree::UnwrapTree(info[1]);
     if (!tree) {
       Nan::ThrowTypeError("Second argument must be a tree");
@@ -385,6 +385,8 @@ void Parser::ParseTextBufferSync(const Nan::FunctionCallbackInfo<Value> &info) {
     }
     old_tree = ts_tree_copy(tree);
   }
+
+  if (!handle_included_ranges(parser->parser_, info[2])) return;
 
   TextBufferInput input(snapshot->slices());
   TSTree *result = ts_parser_parse(parser->parser_, old_tree, input.input());

--- a/src/tree.cc
+++ b/src/tree.cc
@@ -6,7 +6,6 @@
 #include "./logger.h"
 #include "./util.h"
 #include "./conversions.h"
-#include "./tree_cursor.h"
 
 namespace node_tree_sitter {
 
@@ -23,7 +22,6 @@ void Tree::Init(Local<Object> exports) {
 
   FunctionPair methods[] = {
     {"edit", Edit},
-    {"walk", Walk},
     {"rootNode", RootNode},
     {"printDotGraph", PrintDotGraph},
     {"getChangedRanges", GetChangedRanges},
@@ -101,12 +99,6 @@ void Tree::Edit(const Nan::FunctionCallbackInfo<Value> &info) {
   edit.new_end_point = new_end_point.FromJust();
   ts_tree_edit(tree->tree_, &edit);
   info.GetReturnValue().Set(info.This());
-}
-
-void Tree::Walk(const Nan::FunctionCallbackInfo<Value> &info) {
-  Tree *tree = ObjectWrap::Unwrap<Tree>(info.This());
-  TSTreeCursor cursor = ts_tree_cursor_new(ts_tree_root_node(tree->tree_));
-  info.GetReturnValue().Set(TreeCursor::NewInstance(cursor));
 }
 
 void Tree::RootNode(const Nan::FunctionCallbackInfo<Value> &info) {

--- a/src/tree.cc
+++ b/src/tree.cc
@@ -103,7 +103,7 @@ void Tree::Edit(const Nan::FunctionCallbackInfo<Value> &info) {
 
 void Tree::RootNode(const Nan::FunctionCallbackInfo<Value> &info) {
   Tree *tree = ObjectWrap::Unwrap<Tree>(info.This());
-  Node::MarshalNode(ts_tree_root_node(tree->tree_));
+  node_methods::MarshalNode(ts_tree_root_node(tree->tree_));
 }
 
 void Tree::GetChangedRanges(const Nan::FunctionCallbackInfo<Value> &info) {

--- a/src/tree.cc
+++ b/src/tree.cc
@@ -105,7 +105,7 @@ void Tree::Edit(const Nan::FunctionCallbackInfo<Value> &info) {
 
 void Tree::Walk(const Nan::FunctionCallbackInfo<Value> &info) {
   Tree *tree = ObjectWrap::Unwrap<Tree>(info.This());
-  TSTreeCursor cursor = ts_tree_cursor_new(tree->tree_);
+  TSTreeCursor cursor = ts_tree_cursor_new(ts_tree_root_node(tree->tree_));
   info.GetReturnValue().Set(TreeCursor::NewInstance(cursor));
 }
 

--- a/src/tree.h
+++ b/src/tree.h
@@ -22,6 +22,7 @@ class Tree : public Nan::ObjectWrap {
   static void Edit(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void RootNode(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void PrintDotGraph(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void GetEditedRange(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void GetChangedRanges(const Nan::FunctionCallbackInfo<v8::Value> &);
 
   TSTree *tree_;

--- a/src/tree.h
+++ b/src/tree.h
@@ -19,7 +19,6 @@ class Tree : public Nan::ObjectWrap {
   ~Tree();
 
   static void New(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void Walk(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void Edit(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void RootNode(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void PrintDotGraph(const Nan::FunctionCallbackInfo<v8::Value> &);


### PR DESCRIPTION
Depends on https://github.com/tree-sitter/tree-sitter/pull/181

In this PR, I've also added a method for finding the region of a syntax tree that has been directly edited: `Tree.getEditedRange`. This is also useful for https://github.com/atom/atom/pull/17551.

🍐'd with @queerviolet 