### PR TITLE
Fix Typescript types

### DIFF
--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -11,11 +11,11 @@ declare module "tree-sitter" {
 
   export type Edit = {
     startIndex: number;
-    lengthRemoved: number;
-    lengthAdded: number;
+    oldEndIndex: number;
+    newEndIndex: number;
     startPosition: Point;
-    extentRemoved: Point;
-    extentAdded: Point;
+    oldEndPosition: Point;
+    newEndPosition: Point;
   };
 
   export type Logger = (

--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -81,6 +81,7 @@ declare module "tree-sitter" {
     edit(delta: Edit): Document;
     walk(): TreeCursor;
     getChangedRanges(other: Tree): Range[];
+    getEditedRange(other: Tree): Range;
   }
 
   export class Parser {

--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -1,94 +1,99 @@
 declare module "tree-sitter" {
-  export type Point = {
-    row: number;
-    column: number;
-  };
-
-  export type Range = {
-    start: Point;
-    end: Point;
-  };
-
-  export type Edit = {
-    startIndex: number;
-    oldEndIndex: number;
-    newEndIndex: number;
-    startPosition: Point;
-    oldEndPosition: Point;
-    newEndPosition: Point;
-  };
-
-  export type Logger = (
-    message: string,
-    params: {[param: string]: string},
-    type: "parse" | "lex"
-  ) => void;
-
-  export interface Input {
-    seek(index: number): void;
-    read(): any;
-  }
-
-  export interface SyntaxNode {
-    isNamed: boolean;
-    type: string;
-    startPosition: Point;
-    endPosition: Point;
-    children: Array<SyntaxNode>;
-    namedChildren: Array<SyntaxNode>;
-    startIndex: number;
-    endIndex: number;
-    parent: SyntaxNode | null;
-    firstChild: SyntaxNode | null;
-    lastChild: SyntaxNode | null;
-    firstNamedChild: SyntaxNode | null;
-    lastNamedChild: SyntaxNode | null;
-    nextSibling: SyntaxNode | null;
-    nextNamedSibling: SyntaxNode | null;
-    previousSibling: SyntaxNode | null;
-    previousNamedSibling: SyntaxNode | null;
-
-    isValid(): boolean;
-    hasError(): boolean;
-    hasChanges(): boolean;
-    toString(): string;
-    descendantForIndex(index: number): SyntaxNode;
-    descendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
-    namedDescendantForIndex(index: number): SyntaxNode;
-    namedDescendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
-    descendantForPosition(position: Point): SyntaxNode;
-    descendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
-    namedDescendantForPosition(position: Point): SyntaxNode;
-    namedDescendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
-  }
-
-  export interface TreeCursor {
-    nodeType: string;
-    nodeIsNamed: boolean;
-    startPosition: Point;
-    endPosition: Point;
-    startIndex: number;
-    endIndex: number;
-
-    gotoParent(): boolean;
-    gotoFirstChild(): boolean;
-    gotoNextSibling(): boolean;
-  }
-
-  export interface Tree {
-    readonly rootNode: SyntaxNode;
-
-    edit(delta: Edit): Tree;
-    walk(): TreeCursor;
-    getChangedRanges(other: Tree): Range[];
-    getEditedRange(other: Tree): Range;
-  }
-
-  export class Parser {
-    parse(input: string | Input, previousTree?: Tree): Tree;
+  class Parser {
+    parse(input: string | Parser.Input, previousTree?: Parser.Tree): Parser.Tree;
     getLanguage(): any;
     setLanguage(language: any);
-    getLogger(): Logger;
-    setLogger(logFunc: Logger): void;
+    getLogger(): Parser.Logger;
+    setLogger(logFunc: Parser.Logger): void;
   }
+
+  namespace Parser {
+    export type Point = {
+      row: number;
+      column: number;
+    };
+
+    export type Range = {
+      start: Point;
+      end: Point;
+    };
+
+    export type Edit = {
+      startIndex: number;
+      oldEndIndex: number;
+      newEndIndex: number;
+      startPosition: Point;
+      oldEndPosition: Point;
+      newEndPosition: Point;
+    };
+
+    export type Logger = (
+      message: string,
+      params: {[param: string]: string},
+      type: "parse" | "lex"
+    ) => void;
+
+    export interface Input {
+      seek(index: number): void;
+      read(): any;
+    }
+
+    export interface SyntaxNode {
+      isNamed: boolean;
+      type: string;
+      startPosition: Point;
+      endPosition: Point;
+      children: Array<SyntaxNode>;
+      namedChildren: Array<SyntaxNode>;
+      startIndex: number;
+      endIndex: number;
+      parent: SyntaxNode | null;
+      firstChild: SyntaxNode | null;
+      lastChild: SyntaxNode | null;
+      firstNamedChild: SyntaxNode | null;
+      lastNamedChild: SyntaxNode | null;
+      nextSibling: SyntaxNode | null;
+      nextNamedSibling: SyntaxNode | null;
+      previousSibling: SyntaxNode | null;
+      previousNamedSibling: SyntaxNode | null;
+
+      isValid(): boolean;
+      hasError(): boolean;
+      hasChanges(): boolean;
+      toString(): string;
+      descendantForIndex(index: number): SyntaxNode;
+      descendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
+      namedDescendantForIndex(index: number): SyntaxNode;
+      namedDescendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
+      descendantForPosition(position: Point): SyntaxNode;
+      descendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
+      namedDescendantForPosition(position: Point): SyntaxNode;
+      namedDescendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
+    }
+
+    export interface TreeCursor {
+      nodeType: string;
+      nodeIsNamed: boolean;
+      startPosition: Point;
+      endPosition: Point;
+      startIndex: number;
+      endIndex: number;
+
+      gotoParent(): boolean;
+      gotoFirstChild(): boolean;
+      gotoFirstChildForIndex(index: number): boolean;
+      gotoNextSibling(): boolean;
+    }
+
+    export interface Tree {
+      readonly rootNode: SyntaxNode;
+
+      edit(delta: Edit): Tree;
+      walk(): TreeCursor;
+      getChangedRanges(other: Tree): Range[];
+      getEditedRange(other: Tree): Range;
+    }
+  }
+
+  export = Parser
 }

--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -78,7 +78,7 @@ declare module "tree-sitter" {
   export interface Tree {
     readonly rootNode: SyntaxNode;
 
-    edit(delta: Edit): Document;
+    edit(delta: Edit): Tree;
     walk(): TreeCursor;
     getChangedRanges(other: Tree): Range[];
     getEditedRange(other: Tree): Range;

--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -70,26 +70,26 @@ declare module "tree-sitter" {
     startIndex: number;
     endIndex: number;
 
-    public gotoParent(): boolean;
-    public gotoFirstChild(): boolean;
-    public gotoNextSibling(): boolean;
+    gotoParent(): boolean;
+    gotoFirstChild(): boolean;
+    gotoNextSibling(): boolean;
   };
 
   export interface Tree {
-    public readonly rootNode: SyntaxNode;
+    readonly rootNode: SyntaxNode;
 
-    public edit(delta: Edit): Document;
-    public walk(): TreeCursor;
-    public getChangedRanges(other: Tree): Range[];
   };
+    edit(delta: Edit): Document;
+    walk(): TreeCursor;
+    getChangedRanges(other: Tree): Range[];
 
   export class Parser {
-    public parse(input: string | Input, previousTree?: Tree): Tree;
-    public getLanguage(): any;
-    public setLanguage(language: any);
-    public getLogger(): Logger;
-    public setLogger(logFunc: Logger): void;
   };
 
   export = Parser;
+    parse(input: string | Input, previousTree?: Tree): Tree;
+    getLanguage(): any;
+    setLanguage(language: any);
+    getLogger(): Logger;
+    setLogger(logFunc: Logger): void;
 }

--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -27,7 +27,7 @@ declare module "tree-sitter" {
   export interface Input {
     seek(index: number): void;
     read(): any;
-  };
+  }
 
   export interface SyntaxNode {
     isNamed: boolean;
@@ -60,7 +60,7 @@ declare module "tree-sitter" {
     descendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
     namedDescendantForPosition(position: Point): SyntaxNode;
     namedDescendantForPosition(startPosition: Point, endPosition: Point): SyntaxNode;
-  };
+  }
 
   export interface TreeCursor {
     nodeType: string;
@@ -73,18 +73,17 @@ declare module "tree-sitter" {
     gotoParent(): boolean;
     gotoFirstChild(): boolean;
     gotoNextSibling(): boolean;
-  };
+  }
 
   export interface Tree {
     readonly rootNode: SyntaxNode;
 
-  };
     edit(delta: Edit): Document;
     walk(): TreeCursor;
     getChangedRanges(other: Tree): Range[];
+  }
 
   export class Parser {
-  };
 
   export = Parser;
     parse(input: string | Input, previousTree?: Tree): Tree;
@@ -92,4 +91,5 @@ declare module "tree-sitter" {
     setLanguage(language: any);
     getLogger(): Logger;
     setLogger(logFunc: Logger): void;
+  }
 }

--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -84,8 +84,6 @@ declare module "tree-sitter" {
   }
 
   export class Parser {
-
-  export = Parser;
     parse(input: string | Input, previousTree?: Tree): Tree;
     getLanguage(): any;
     setLanguage(language: any);


### PR DESCRIPTION
These changes:

* Fix several Typescript errors (given in the extended commit message for the fix)
* Updates the type organization to more closely match the exports of the module
* Updates a few of the types to match the current library API (eg `Edit` was wrong, `Document` was still being referred to, etc)

The correct way to do Typescript imports is now like this:
```typescript
import * as Parser from 'tree-sitter';
import { Point, SyntaxNode, Tree } from 'tree-sitter';
```