### PR TITLE
Update the start positions of referenced nodes when editing a syntax tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,11 @@ class SyntaxNode {
     return NodeMethods.previousNamedSibling(this.tree) || unmarshalNode(this.tree);
   }
 
+  hasChanges() {
+    marshalNode(this);
+    return NodeMethods.hasChanges(this.tree);
+  }
+
   hasError() {
     marshalNode(this);
     return NodeMethods.hasError(this.tree);

--- a/index.js
+++ b/index.js
@@ -15,13 +15,11 @@ const {rootNode} = Tree.prototype;
 
 Object.defineProperty(Tree.prototype, 'rootNode', {
   get() {
-    if (!this._nodes) this._nodes = {};
-    rootNode.call(this);
-    return unmarshalNode(this);
+    return rootNode.call(this) || unmarshalNode(this);
   }
 })
 
-Tree.prototype.walk = function () {
+Tree.prototype.walk = function() {
   return this.rootNode.walk()
 }
 
@@ -64,8 +62,7 @@ class SyntaxNode {
 
   get parent() {
     marshalNode(this);
-    NodeMethods.parent(this.tree);
-    return unmarshalNode(this.tree);
+    return NodeMethods.parent(this.tree) || unmarshalNode(this.tree);
   }
 
   get children() {
@@ -98,50 +95,42 @@ class SyntaxNode {
 
   get firstChild() {
     marshalNode(this);
-    NodeMethods.firstChild(this.tree);
-    return unmarshalNode(this.tree);
+    return NodeMethods.firstChild(this.tree) || unmarshalNode(this.tree);
   }
 
   get firstNamedChild() {
     marshalNode(this);
-    NodeMethods.firstNamedChild(this.tree);
-    return unmarshalNode(this.tree);
+    return NodeMethods.firstNamedChild(this.tree) || unmarshalNode(this.tree);
   }
 
   get lastChild() {
     marshalNode(this);
-    NodeMethods.lastChild(this.tree);
-    return unmarshalNode(this.tree);
+    return NodeMethods.lastChild(this.tree) || unmarshalNode(this.tree);
   }
 
   get lastNamedChild() {
     marshalNode(this);
-    NodeMethods.lastNamedChild(this.tree);
-    return unmarshalNode(this.tree);
+    return NodeMethods.lastNamedChild(this.tree) || unmarshalNode(this.tree);
   }
 
   get nextSibling() {
     marshalNode(this);
-    NodeMethods.nextSibling(this.tree);
-    return unmarshalNode(this.tree);
+    return NodeMethods.nextSibling(this.tree) || unmarshalNode(this.tree);
   }
 
   get nextNamedSibling() {
     marshalNode(this);
-    NodeMethods.nextNamedSibling(this.tree);
-    return unmarshalNode(this.tree);
+    return NodeMethods.nextNamedSibling(this.tree) || unmarshalNode(this.tree);
   }
 
   get previousSibling() {
     marshalNode(this);
-    NodeMethods.previousSibling(this.tree);
-    return unmarshalNode(this.tree);
+    return NodeMethods.previousSibling(this.tree) || unmarshalNode(this.tree);
   }
 
   get previousNamedSibling() {
     marshalNode(this);
-    NodeMethods.previousNamedSibling(this.tree);
-    return unmarshalNode(this.tree);
+    return NodeMethods.previousNamedSibling(this.tree) || unmarshalNode(this.tree);
   }
 
   hasError() {
@@ -161,72 +150,73 @@ class SyntaxNode {
 
   child(index) {
     marshalNode(this);
-    NodeMethods.child(this.tree, index);
-    return unmarshalNode(this.tree);
+    return NodeMethods.child(this.tree, index) || unmarshalNode(this.tree);
   }
 
   namedChild(index) {
     marshalNode(this);
-    NodeMethods.namedChild(this.tree, index);
-    return unmarshalNode(this.tree);
+    return NodeMethods.namedChild(this.tree, index) || unmarshalNode(this.tree);
   }
 
   firstChildForIndex(index) {
     marshalNode(this);
-    NodeMethods.firstChildForIndex(this.tree, index);
-    return unmarshalNode(this.tree);
+    return NodeMethods.firstChildForIndex(this.tree, index) || unmarshalNode(this.tree);
   }
 
   firstNamedChildForIndex(index) {
     marshalNode(this);
-    NodeMethods.firstNamedChildForIndex(this.tree, index);
-    return unmarshalNode(this.tree);
+    return NodeMethods.firstNamedChildForIndex(this.tree, index) || unmarshalNode(this.tree);
   }
 
   namedDescendantForIndex(start, end) {
     marshalNode(this);
+    let result
     if (end != null) {
-      NodeMethods.namedDescendantForIndex(this.tree, start, end);
+      result = NodeMethods.namedDescendantForIndex(this.tree, start, end);
     } else {
-      NodeMethods.namedDescendantForIndex(this.tree, start, start);
+      result = NodeMethods.namedDescendantForIndex(this.tree, start, start);
     }
-    return unmarshalNode(this.tree);
+    return result || unmarshalNode(this.tree);
   }
 
   descendantForIndex(start, end) {
     marshalNode(this);
+    let result
     if (end != null) {
-      NodeMethods.descendantForIndex(this.tree, start, end);
+      result = NodeMethods.descendantForIndex(this.tree, start, end);
     } else {
-      NodeMethods.descendantForIndex(this.tree, start, start);
+      result = NodeMethods.descendantForIndex(this.tree, start, start);
     }
-    return unmarshalNode(this.tree);
+    return result || unmarshalNode(this.tree);
   }
 
   descendantsOfType(type, start, end) {
     marshalNode(this);
-    const count = NodeMethods.descendantsOfType(this.tree, type, start, end);
-    return unmarshalNodes(this.tree, count);
+    const nodes = NodeMethods.descendantsOfType(this.tree, type, start, end);
+    unmarshalNodes(this.tree, nodes);
+    return nodes
   }
 
   namedDescendantForPosition(start, end) {
     marshalNode(this);
+    let result
     if (end != null) {
-      NodeMethods.namedDescendantForPosition(this.tree, start, end);
+      result = NodeMethods.namedDescendantForPosition(this.tree, start, end);
     } else {
-      NodeMethods.namedDescendantForPosition(this.tree, start, start);
+      result = NodeMethods.namedDescendantForPosition(this.tree, start, start);
     }
-    return unmarshalNode(this.tree);
+    return result || unmarshalNode(this.tree);
   }
 
   descendantForPosition(start, end) {
     marshalNode(this);
+    let result
     if (end != null) {
-      NodeMethods.descendantForPosition(this.tree, start, end);
+      result = NodeMethods.descendantForPosition(this.tree, start, end);
     } else {
-      NodeMethods.descendantForPosition(this.tree, start, start);
+      result = NodeMethods.descendantForPosition(this.tree, start, start);
     }
-    return unmarshalNode(this.tree);
+    return result || unmarshalNode(this.tree);
   }
 
   walk () {
@@ -329,27 +319,25 @@ const NODE_FIELD_COUNT = 6;
 
 function unmarshalNode(tree, offset = 0) {
   const {nodeTransferArray} = binding;
-  const key = `${nodeTransferArray[offset]}${nodeTransferArray[offset + 1]}`
-  if (key === '00') return null;
-  let result = tree._nodes[key];
-  if (!result) {
-    result = new SyntaxNode(tree);
-    tree._nodes[key] = result;
+  if (nodeTransferArray[0] || nodeTransferArray[1]) {
+    const result = new SyntaxNode(tree);
+    for (let i = 0; i < NODE_FIELD_COUNT; i++) {
+      result[i] = nodeTransferArray[offset + i];
+    }
+    tree._cacheNode(result);
+    return result;
   }
-  for (let i = 0; i < NODE_FIELD_COUNT; i++) {
-    result[i] = nodeTransferArray[offset + i];
-  }
-  return result;
+  return null
 }
 
-function unmarshalNodes(tree, count) {
-  const result = new Array(count);
+function unmarshalNodes(tree, nodes) {
   let offset = 0;
-  for (let i = 0; i < count; i++) {
-    result[i] = unmarshalNode(tree, offset)
-    offset += 6
+  for (let i = 0, {length} = nodes; i < length; i++) {
+    if (!nodes[i]) {
+      nodes[i] = unmarshalNode(tree, offset)
+      offset += NODE_FIELD_COUNT
+    }
   }
-  return result
 }
 
 function marshalNode(node) {

--- a/index.js
+++ b/index.js
@@ -11,17 +11,29 @@ try {
 
 const {Parser, NodeMethods, Tree, TreeCursor} = binding;
 
-const {rootNode} = Tree.prototype;
+const {rootNode, edit} = Tree.prototype;
 
 Object.defineProperty(Tree.prototype, 'rootNode', {
   get() {
     return rootNode.call(this) || unmarshalNode(this);
   }
-})
+});
+
+Tree.prototype.edit = function(arg) {
+  edit.call(
+    this,
+    arg.startPosition.row, arg.startPosition.column,
+    arg.oldEndPosition.row, arg.oldEndPosition.column,
+    arg.newEndPosition.row, arg.newEndPosition.column,
+    arg.startIndex,
+    arg.oldEndIndex,
+    arg.newEndIndex
+  );
+};
 
 Tree.prototype.walk = function() {
   return this.rootNode.walk()
-}
+};
 
 class SyntaxNode {
   constructor(tree) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter",
-  "version": "0.12.19",
+  "version": "0.12.20-0",
   "description": "Incremental parsers for node",
   "author": "Max Brunsfeld",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter",
-  "version": "0.12.20-0",
+  "version": "0.12.20-1",
   "description": "Incremental parsers for node",
   "author": "Max Brunsfeld",
   "license": "MIT",

--- a/src/node.h
+++ b/src/node.h
@@ -5,12 +5,24 @@
 #include <v8.h>
 #include <node_object_wrap.h>
 #include <tree_sitter/runtime.h>
+#include "./tree.h"
 
 namespace node_tree_sitter {
 namespace node_methods {
 
 void Init(v8::Local<v8::Object>);
-void MarshalNode(TSNode);
+void MarshalNode(const Nan::FunctionCallbackInfo<v8::Value> &info, const Tree *, TSNode);
+
+static inline const void *UnmarshalNodeId(const uint32_t *buffer) {
+  const void *result;
+  memcpy(&result, buffer, sizeof(result));
+  return result;
+}
+
+static inline void MarshalNodeId(const void *id, uint32_t *buffer) {
+  memset(buffer, 0, sizeof(id));
+  memcpy(buffer, &id, sizeof(id));
+}
 
 }  // namespace node_methods
 }  // namespace node_tree_sitter

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -273,12 +273,12 @@ void Parser::Parse(const Nan::FunctionCallbackInfo<Value> &info) {
 
   const TSTree *old_tree = nullptr;
   if (info.Length() > 1 && info[1]->BooleanValue()) {
-    const TSTree *tree = Tree::UnwrapTree(info[1]);
+    const Tree *tree = Tree::UnwrapTree(info[1]);
     if (!tree) {
       Nan::ThrowTypeError("Second argument must be a tree");
       return;
     }
-    old_tree = tree;
+    old_tree = tree->tree_;
   }
 
   Local<Value> buffer_size = Nan::Null();
@@ -331,11 +331,12 @@ void Parser::ParseTextBuffer(const Nan::FunctionCallbackInfo<Value> &info) {
 
   const TSTree *old_tree = nullptr;
   if (info.Length() > 2 && info[2]->BooleanValue()) {
-    old_tree = Tree::UnwrapTree(info[2]);
-    if (!old_tree) {
+    const Tree *tree = Tree::UnwrapTree(info[2]);
+    if (!tree) {
       Nan::ThrowTypeError("Second argument must be a tree");
       return;
     }
+    old_tree = tree->tree_;
   }
 
   if (!handle_included_ranges(parser->parser_, info[3])) return;
@@ -383,12 +384,12 @@ void Parser::ParseTextBufferSync(const Nan::FunctionCallbackInfo<Value> &info) {
 
   TSTree *old_tree = nullptr;
   if (info.Length() > 1 && info[1]->BooleanValue()) {
-    const TSTree *tree = Tree::UnwrapTree(info[1]);
+    const Tree *tree = Tree::UnwrapTree(info[1]);
     if (!tree) {
       Nan::ThrowTypeError("Second argument must be a tree");
       return;
     }
-    old_tree = ts_tree_copy(tree);
+    old_tree = ts_tree_copy(tree->tree_);
   }
 
   if (!handle_included_ranges(parser->parser_, info[2])) return;

--- a/src/tree.cc
+++ b/src/tree.cc
@@ -10,6 +10,7 @@
 namespace node_tree_sitter {
 
 using namespace v8;
+using node_methods::UnmarshalNodeId;
 
 Nan::Persistent<Function> Tree::constructor;
 Nan::Persistent<FunctionTemplate> Tree::constructor_template;
@@ -26,6 +27,7 @@ void Tree::Init(Local<Object> exports) {
     {"printDotGraph", PrintDotGraph},
     {"getChangedRanges", GetChangedRanges},
     {"getEditedRange", GetEditedRange},
+    {"_cacheNode", CacheNode},
   };
 
   for (size_t i = 0; i < length_of_array(methods); i++) {
@@ -41,7 +43,12 @@ void Tree::Init(Local<Object> exports) {
 
 Tree::Tree(TSTree *tree) : tree_(tree) {}
 
-Tree::~Tree() { ts_tree_delete(tree_); }
+Tree::~Tree() {
+  ts_tree_delete(tree_);
+  for (auto &entry : cached_nodes_) {
+    entry.second->tree = nullptr;
+  }
+}
 
 Local<Value> Tree::NewInstance(TSTree *tree) {
   if (tree) {
@@ -55,14 +62,11 @@ Local<Value> Tree::NewInstance(TSTree *tree) {
   return Nan::Null();
 }
 
-const TSTree *Tree::UnwrapTree(const Local<Value> &value) {
+const Tree *Tree::UnwrapTree(const Local<Value> &value) {
   if (!value->IsObject()) return nullptr;
   Local<Object> js_tree = Local<Object>::Cast(value);
-  if (!Nan::New(constructor_template)->HasInstance(js_tree)) {
-    return nullptr;
-  }
-
-  return ObjectWrap::Unwrap<Tree>(js_tree)->tree_;
+  if (!Nan::New(constructor_template)->HasInstance(js_tree)) return nullptr;
+  return ObjectWrap::Unwrap<Tree>(js_tree);
 }
 
 void Tree::New(const Nan::FunctionCallbackInfo<Value> &info) {
@@ -99,24 +103,40 @@ void Tree::Edit(const Nan::FunctionCallbackInfo<Value> &info) {
   edit.old_end_point = old_end_point.FromJust();
   edit.new_end_point = new_end_point.FromJust();
   ts_tree_edit(tree->tree_, &edit);
+
+  for (auto &entry : tree->cached_nodes_) {
+    Local<Object> js_node = Nan::New(entry.second->node);
+    TSNode node;
+    node.id = entry.first;
+    for (unsigned i = 0; i < 4; i++) {
+      node.context[i] = js_node->Get(i + 2)->Uint32Value();
+    }
+
+    ts_node_edit(&node, &edit);
+
+    for (unsigned i = 0; i < 4; i++) {
+      js_node->Set(i + 2, Nan::New(node.context[i]));
+    }
+  }
+
   info.GetReturnValue().Set(info.This());
 }
 
 void Tree::RootNode(const Nan::FunctionCallbackInfo<Value> &info) {
   Tree *tree = ObjectWrap::Unwrap<Tree>(info.This());
-  node_methods::MarshalNode(ts_tree_root_node(tree->tree_));
+  node_methods::MarshalNode(info, tree, ts_tree_root_node(tree->tree_));
 }
 
 void Tree::GetChangedRanges(const Nan::FunctionCallbackInfo<Value> &info) {
-  Tree *tree = ObjectWrap::Unwrap<Tree>(info.This());
-  const TSTree *other_tree = UnwrapTree(info[0]);
+  const Tree *tree = ObjectWrap::Unwrap<Tree>(info.This());
+  const Tree *other_tree = UnwrapTree(info[0]);
   if (!other_tree) {
     Nan::ThrowTypeError("Argument must be a tree");
     return;
   }
 
   uint32_t range_count;
-  TSRange *ranges = ts_tree_get_changed_ranges(tree->tree_, other_tree, &range_count);
+  TSRange *ranges = ts_tree_get_changed_ranges(tree->tree_, other_tree->tree_, &range_count);
 
   Local<Array> result = Nan::New<Array>();
   for (size_t i = 0; i < range_count; i++) {
@@ -174,11 +194,42 @@ void Tree::GetEditedRange(const Nan::FunctionCallbackInfo<Value> &info) {
   info.GetReturnValue().Set(RangeToJS(result));
 }
 
-
 void Tree::PrintDotGraph(const Nan::FunctionCallbackInfo<Value> &info) {
   Tree *tree = ObjectWrap::Unwrap<Tree>(info.This());
   ts_tree_print_dot_graph(tree->tree_, stderr);
   info.GetReturnValue().Set(info.This());
+}
+
+static void FinalizeNode(const v8::WeakCallbackInfo<Tree::NodeCacheEntry> &info) {
+  Tree::NodeCacheEntry *cache_entry = info.GetParameter();
+  assert(cache_entry->node.IsNearDeath());
+  assert(!cache_entry->node.IsEmpty());
+  cache_entry->node.Reset();
+  if (cache_entry->tree) {
+    assert(cache_entry->tree->cached_nodes_.count(cache_entry->key));
+    cache_entry->tree->cached_nodes_.erase(cache_entry->key);
+  }
+  delete cache_entry;
+}
+
+void Tree::CacheNode(const Nan::FunctionCallbackInfo<Value> &info) {
+  Tree *tree = ObjectWrap::Unwrap<Tree>(info.This());
+  Local<Object> js_node = Local<Object>::Cast(info[0]);
+
+  uint32_t key_parts[2] = {
+    js_node->Get(0)->Uint32Value(),
+    js_node->Get(1)->Uint32Value(),
+  };
+  const void *key = UnmarshalNodeId(key_parts);
+
+  auto cache_entry = new NodeCacheEntry{tree, key, {}};
+  cache_entry->node.Reset(info.GetIsolate(), js_node);
+  cache_entry->node.SetWeak(cache_entry, &FinalizeNode, Nan::WeakCallbackType::kParameter);
+  cache_entry->node.MarkIndependent();
+
+  assert(!tree->cached_nodes_.count(key));
+
+  tree->cached_nodes_[key] = cache_entry;
 }
 
 }  // namespace node_tree_sitter

--- a/src/tree.h
+++ b/src/tree.h
@@ -4,6 +4,7 @@
 #include <v8.h>
 #include <nan.h>
 #include <node_object_wrap.h>
+#include <unordered_map>
 #include <tree_sitter/runtime.h>
 
 namespace node_tree_sitter {
@@ -12,7 +13,16 @@ class Tree : public Nan::ObjectWrap {
  public:
   static void Init(v8::Local<v8::Object> exports);
   static v8::Local<v8::Value> NewInstance(TSTree *);
-  static const TSTree *UnwrapTree(const v8::Local<v8::Value> &);
+  static const Tree *UnwrapTree(const v8::Local<v8::Value> &);
+
+  struct NodeCacheEntry {
+    Tree *tree;
+    const void *key;
+    v8::Persistent<v8::Object> node;
+  };
+
+  TSTree *tree_;
+  std::unordered_map<const void *, NodeCacheEntry *> cached_nodes_;
 
  private:
   explicit Tree(TSTree *);
@@ -24,8 +34,8 @@ class Tree : public Nan::ObjectWrap {
   static void PrintDotGraph(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void GetEditedRange(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void GetChangedRanges(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void CacheNode(const Nan::FunctionCallbackInfo<v8::Value> &);
 
-  TSTree *tree_;
   static Nan::Persistent<v8::Function> constructor;
   static Nan::Persistent<v8::FunctionTemplate> constructor_template;
 };


### PR DESCRIPTION
In this PR, we've moved the syntax tree's cache of nodes from JS into C++. This allows us to use *weak* references in the cache, so that we'll only maintain pointers to nodes that are retained elsewhere. This way, when we edit the syntax tree, we'll know which syntax nodes we need to update.

🍐'd with @queerviolet 

Fixes https://github.com/tree-sitter/node-tree-sitter/issues/17