### PR TITLE
Prebuild support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,18 @@ os:
 before_install:
   - git submodule update --init --recursive
 
-script:
-  - npm run prebuild
-  - npm run prebuild:upload -u ${PREBUILD_UPLOAD}
-
 branches:
   only:
     - master
+    - /^v.*$/
+
+script:
+  - npm test
+
+deploy:
+  provider: script
+  script: npm run prebuild && npm run prebuild:upload -u ${PREBUILD_UPLOAD}
+  skip_cleanup: true
+  on:
+    all_branches: true
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ branches:
     - master
     - /^v.*$/
 
-script:
-  - npm test
-
 deploy:
   provider: script
   script: npm run prebuild && npm run prebuild:upload -u ${PREBUILD_UPLOAD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,16 @@ language: node_js
 node_js:
   - "node"
 
+os:
+- linux
+- osx
+
 before_install:
   - git submodule update --init --recursive
+
+script:
+  - npm run prebuild
+  - npm run prebuild:upload -u ${PREBUILD_UPLOAD}
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,6 @@ install:
 
 build: off
 
-test_script:
-  - npm test
-
 branches:
   only:
     - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  nodejs_version: "6"
+  nodejs_version: "10"
 
 platform:
   - x64
@@ -11,6 +11,10 @@ install:
   - npm install
 
 build: off
+
+test_script:
+  - npm run prebuild
+  - npm run prebuild:upload -u %PREBUILD_UPLOAD%
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,11 @@ install:
 build: off
 
 test_script:
-  - npm run prebuild
-  - npm run prebuild:upload -u %PREBUILD_UPLOAD%
+  - npm test
 
 branches:
   only:
     - master
+    - /^v.*$/
+
+deploy_script: IF "%APPVEYOR_REPO_TAG%" == "true" (npm run prebuild && npm run prebuild:upload -u %PREBUILD_UPLOAD%)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",
     "prebuild": "prebuild --all --strip --verbose",
-    "prebuild:upload": "prebuild --upload-all"
+    "prebuild:upload": "prebuild --upload-all",
+    "test": "echo 'node-tree-sitter'"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,12 @@
   "types": "tree-sitter.d.ts",
   "dependencies": {
     "nan": "^2.10.0"
+  },
+  "devDependencies": {
+    "prebuild": "^7.6.0"
+  },
+  "scripts": {
+    "prebuild": "prebuild --all --strip --verbose",
+    "prebuild:upload": "prebuild --upload-all"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
   "main": "index.js",
   "types": "tree-sitter.d.ts",
   "dependencies": {
-    "nan": "^2.10.0"
+    "nan": "^2.10.0",
+    "prebuild-install": "^5.0.0"
   },
   "devDependencies": {
     "prebuild": "^7.6.0"
   },
   "scripts": {
+    "install": "prebuild-install || node-gyp rebuild",
     "prebuild": "prebuild --all --strip --verbose",
     "prebuild:upload": "prebuild --upload-all"
   }


### PR DESCRIPTION
This adds support to prebuild binaries via [prebuild](https://github.com/prebuild/prebuild). This will prebuild binaries in Darwin, Linux, and Windows (32 and 64 bit) for all [supported targets in the node-api project](https://github.com/lgeiger/node-abi/blob/master/index.js#L51-L68). You can see how the binaries end up being built/uploaded on my test release version [v0.12.16.2](https://github.com/wingrunr21/node-tree-sitter/releases/tag/v0.12.16.2).

I'm hoping the Travis Linux OS is enough to provide support for Linux electron builds. If additional binaries are required the TravisCI config might have to be modified to build under additional Linux targets.

[prebuild-install](https://github.com/prebuild/prebuild-install) is used to download the prebuilt binaries via a custom `install` script.

Only configuration that is needed would be for you to add a Github Personal Access Token with the `repo` scope as a secure environment variable named `PREBUILD_UPLOAD` in both TravisCI and AppVeyor. See the [prebuild docs](https://github.com/prebuild/prebuild#uploading) as to why.

This resolves #16 