### PR TITLE
Add text accessors for nodes and tree cursors

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,7 +280,7 @@ Parser.prototype.getLanguage = function(language) {
 };
 
 Parser.prototype.parse = function(input, oldTree, {bufferSize, includedRanges}={}) {
-  let getText
+  let getText, treeInput = input
   if (typeof input === 'string') {
     const inputString = input;
     input = (offset, position) => inputString.slice(offset)
@@ -295,8 +295,10 @@ Parser.prototype.parse = function(input, oldTree, {bufferSize, includedRanges}={
     bufferSize,
     includedRanges
   );
-  tree.input = input
-  tree.getText = getText
+  if (tree) {
+    tree.input = treeInput
+    tree.getText = getText
+  }
   return tree
 };
 
@@ -308,11 +310,13 @@ Parser.prototype.parseTextBuffer = function(
   return new Promise(resolve => {
     parseTextBuffer.call(
       this,
-      result => {
+      tree => {
         snapshot.destroy();
-        result.input = buffer
-        result.getText = getTextFromTextBuffer
-        resolve(result);
+        if (tree) {
+          tree.input = buffer
+          tree.getText = getTextFromTextBuffer
+        }
+        resolve(tree);
       },
       snapshot,
       oldTree,
@@ -325,8 +329,10 @@ Parser.prototype.parseTextBuffer = function(
 Parser.prototype.parseTextBufferSync = function(buffer, oldTree, {includedRanges}={}) {
   const snapshot = buffer.getSnapshot();
   const tree = parseTextBufferSync.call(this, snapshot, oldTree, includedRanges);
-  tree.input = buffer;
-  tree.getText = getTextFromTextBuffer;
+  if (tree) {
+    tree.input = buffer;
+    tree.getText = getTextFromTextBuffer;
+  }
   snapshot.destroy();
   return tree;
 };

--- a/index.js
+++ b/index.js
@@ -40,6 +40,15 @@ class SyntaxNode {
     this.tree = tree;
   }
 
+  inspect() {
+    return 'SyntaxNode {\n' +
+      '  type: ' + this.type + ',\n' +
+      '  startPosition: ' + pointToString(this.startPosition) + ',\n' +
+      '  endPosition: ' + pointToString(this.startPosition) + ',\n' +
+      '  childCount: ' + this.childCount + ',\n' +
+      '}'
+  }
+
   get type() {
     marshalNode(this);
     return NodeMethods.type(this.tree);
@@ -414,6 +423,10 @@ function marshalNode(node) {
 
 function unmarshalPoint() {
   return {row: pointTransferArray[0], column: pointTransferArray[1]};
+}
+
+function pointToString(point) {
+  return `{row: ${point.row}, column: ${point.column}}`;
 }
 
 module.exports = Parser;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter",
-  "version": "0.13.2-0",
+  "version": "0.13.2-1",
   "description": "Incremental parsers for node",
   "author": "Max Brunsfeld",
   "license": "MIT",


### PR DESCRIPTION
This adds a `.text` property to syntax nodes so that you can conveniently access their text without having to manually slice the source string using the node's `startIndex` and `endIndex`.

I was originally hesitant to add this because it was trivially achievable already and I wasn't sure if all applications would want to retain the source string in memory after parsing, but it seems like most users probably want this.

Closes https://github.com/tree-sitter/node-tree-sitter/issues/22