### PR TITLE
Add reset and currentNode support to TreeCursor

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,7 +339,7 @@ Parser.prototype.parseTextBufferSync = function(buffer, oldTree, {includedRanges
   return tree;
 };
 
-const {startPosition, endPosition, currentNode} = TreeCursor.prototype;
+const {startPosition, endPosition, currentNode, reset} = TreeCursor.prototype;
 
 Object.defineProperties(TreeCursor.prototype, {
   currentNode: {
@@ -365,6 +365,11 @@ Object.defineProperties(TreeCursor.prototype, {
     }
   }
 });
+
+TreeCursor.prototype.reset = function(node) {
+  marshalNode(node);
+  reset.call(this);
+}
 
 function getTextFromString (node) {
   return this.input.substring(node.startIndex, node.endIndex);

--- a/index.js
+++ b/index.js
@@ -339,9 +339,14 @@ Parser.prototype.parseTextBufferSync = function(buffer, oldTree, {includedRanges
   return tree;
 };
 
-const {startPosition, endPosition} = TreeCursor.prototype;
+const {startPosition, endPosition, currentNode} = TreeCursor.prototype;
 
 Object.defineProperties(TreeCursor.prototype, {
+  currentNode: {
+    get() {
+      return currentNode.call(this) || unmarshalNode(this.tree);
+    }
+  },
   startPosition: {
     get() {
       startPosition.call(this);

--- a/src/node.cc
+++ b/src/node.cc
@@ -85,7 +85,7 @@ void MarshalNullNode() {
   memset(transfer_buffer, 0, FIELD_COUNT_PER_NODE * sizeof(transfer_buffer[0]));
 }
 
-static TSNode UnmarshalNode(const Tree *tree) {
+TSNode UnmarshalNode(const Tree *tree) {
   TSNode result = {{0, 0, 0, 0}, nullptr, nullptr};
   result.tree = tree->tree_;
   if (!result.tree) {

--- a/src/node.h
+++ b/src/node.h
@@ -12,6 +12,7 @@ namespace node_methods {
 
 void Init(v8::Local<v8::Object>);
 void MarshalNode(const Nan::FunctionCallbackInfo<v8::Value> &info, const Tree *, TSNode);
+TSNode UnmarshalNode(const Tree *tree);
 
 static inline const void *UnmarshalNodeId(const uint32_t *buffer) {
   const void *result;

--- a/src/tree_cursor.cc
+++ b/src/tree_cursor.cc
@@ -4,6 +4,8 @@
 #include <v8.h>
 #include "./util.h"
 #include "./conversions.h"
+#include "./node.h"
+#include "./tree.h"
 
 namespace node_tree_sitter {
 
@@ -31,6 +33,7 @@ void TreeCursor::Init(v8::Local<v8::Object> exports) {
     {"gotoFirstChild", GotoFirstChild},
     {"gotoFirstChildForIndex", GotoFirstChildForIndex},
     {"gotoNextSibling", GotoNextSibling},
+    {"currentNode", CurrentNode},
   };
 
   for (size_t i = 0; i < length_of_array(getters); i++) {
@@ -110,6 +113,14 @@ void TreeCursor::EndPosition(const Nan::FunctionCallbackInfo<Value> &info) {
   TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
   TransferPoint(ts_node_end_point(node));
+}
+
+void TreeCursor::CurrentNode(const Nan::FunctionCallbackInfo<Value> &info) {
+  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+  Local<String> key = Nan::New<String>("tree").ToLocalChecked();
+  const Tree *tree = Tree::UnwrapTree(info.This()->Get(key));
+  TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
+  node_methods::MarshalNode(info, tree, node);
 }
 
 void TreeCursor::NodeType(v8::Local<v8::String> prop, const Nan::PropertyCallbackInfo<v8::Value> &info) {

--- a/src/tree_cursor.cc
+++ b/src/tree_cursor.cc
@@ -34,6 +34,7 @@ void TreeCursor::Init(v8::Local<v8::Object> exports) {
     {"gotoFirstChildForIndex", GotoFirstChildForIndex},
     {"gotoNextSibling", GotoNextSibling},
     {"currentNode", CurrentNode},
+    {"reset", Reset},
   };
 
   for (size_t i = 0; i < length_of_array(getters); i++) {
@@ -121,6 +122,14 @@ void TreeCursor::CurrentNode(const Nan::FunctionCallbackInfo<Value> &info) {
   const Tree *tree = Tree::UnwrapTree(info.This()->Get(key));
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
   node_methods::MarshalNode(info, tree, node);
+}
+
+void TreeCursor::Reset(const Nan::FunctionCallbackInfo<Value> &info) {
+  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+  Local<String> key = Nan::New<String>("tree").ToLocalChecked();
+  const Tree *tree = Tree::UnwrapTree(info.This()->Get(key));
+  TSNode node = node_methods::UnmarshalNode(tree);
+  ts_tree_cursor_reset(&cursor->cursor_, node);
 }
 
 void TreeCursor::NodeType(v8::Local<v8::String> prop, const Nan::PropertyCallbackInfo<v8::Value> &info) {

--- a/src/tree_cursor.h
+++ b/src/tree_cursor.h
@@ -25,6 +25,7 @@ class TreeCursor : public Nan::ObjectWrap {
   static void StartPosition(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void EndPosition(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void CurrentNode(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void Reset(const Nan::FunctionCallbackInfo<v8::Value> &);
 
   static void NodeType(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
   static void NodeIsNamed(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);

--- a/src/tree_cursor.h
+++ b/src/tree_cursor.h
@@ -24,6 +24,7 @@ class TreeCursor : public Nan::ObjectWrap {
   static void GotoNextSibling(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void StartPosition(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void EndPosition(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void CurrentNode(const Nan::FunctionCallbackInfo<v8::Value> &);
 
   static void NodeType(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
   static void NodeIsNamed(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);

--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -94,6 +94,7 @@ declare module "tree-sitter" {
       endIndex: number;
       readonly currentNode: SyntaxNode
 
+      reset(node: SyntaxNode): void
       gotoParent(): boolean;
       gotoFirstChild(): boolean;
       gotoFirstChildForIndex(index: number): boolean;

--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -92,6 +92,7 @@ declare module "tree-sitter" {
       endPosition: Point;
       startIndex: number;
       endIndex: number;
+      readonly currentNode: SyntaxNode
 
       gotoParent(): boolean;
       gotoFirstChild(): boolean;


### PR DESCRIPTION
This PR adds support to the `TreeCursor` object for `ts_tree_cursor_current_node` and `ts_tree_cursor_reset` as discussed in #30 and #31.

A few notes on the implementation:

1. I had to make `UnmarshalNode` a non-static function so I could use it in `TreeCursor::Reset`. I think it could be kept `static` but we'd need to suppress the GCC warnings. I didn't see a reason making it non-static could be detrimental but I might be missing some context.
2. The way I got at the `Tree` instance in the cursor in order to marshal/unmarshal the nodes works but I feel like there's a better way to do it.
3. Both functions make the assumption that the tree exists as an attribute on the cursor. Given this assignment is done in the `walk` method of `SyntaxNode`, this is a bit of a bummer. I'm thinking a future pass might want to actually define a `Tree` attribute on `TreeCursor` itself. That'll also save having to pull the tree out of the V8 object.
