### PR TITLE
Update to latest Tree-sitter

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -42,9 +42,6 @@
         "vendor/tree-sitter/lib/include",
         "vendor/tree-sitter/lib/utf8proc",
       ],
-      'defines': [
-        'UTF8PROC_STATIC',
-      ],
       "cflags": [
         "-std=c99"
       ]

--- a/index.js
+++ b/index.js
@@ -299,7 +299,7 @@ Parser.prototype.parse = function(input, oldTree, {bufferSize, includedRanges}={
 
 Parser.prototype.parseTextBuffer = function(
   buffer, oldTree,
-  {syncOperationLimit, includedRanges} = {}
+  {syncTimeoutMicros, includedRanges} = {}
 ) {
   let tree
   let resolveTreePromise
@@ -319,12 +319,12 @@ Parser.prototype.parseTextBuffer = function(
     snapshot,
     oldTree,
     includedRanges,
-    syncOperationLimit
+    syncTimeoutMicros
   );
 
-  // If the parse finished synchronously because of the given `syncOperationLimit`,
-  // then return the tree immediately so that callers have the option of continuing
-  // synchronously.
+  // If the parse finished synchronously within the time specified by the
+  // `syncTimeoutMicros` parameter, then return the tree immediately
+  // so that callers have the option of continuing synchronously.
   return tree || treePromise
 };
 


### PR DESCRIPTION
This PR bumps Tree-sitter, bringing in this change: https://github.com/tree-sitter/tree-sitter/pull/301. I've updated the `Parser.parseTextBuffer` API to use the new timeout functionality.

Now, instead of this:

```js
const tree = await parser.parseTextBuffer(buffer, oldTree, {
  syncOperationLimit: 1000 // 1000 abstract "parsing operations"
})
```

you do this:

```js
const tree = await parser.parseTextBuffer(buffer, oldTree, {
  syncTimeoutMicros: 1500  // 1.5 milliseconds
})```