### PR TITLE
Auto-generate Node subclasses with getters for node fields

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,6 +14,9 @@ install:
 
 build: off
 
+test_script:
+  - npm test
+
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-- node
+- 10
 
 matrix:
   include:

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,6 +6,7 @@
       "sources": [
         "src/binding.cc",
         "src/conversions.cc",
+        "src/language.cc",
         "src/logger.cc",
         "src/node.cc",
         "src/parser.cc",

--- a/index.js
+++ b/index.js
@@ -379,6 +379,7 @@ function getTextFromTextBuffer ({startPosition, endPosition}) {
 const {pointTransferArray} = binding;
 
 const NODE_FIELD_COUNT = 6;
+const ERROR_TYPE_ID = 0xFFFF
 
 function unmarshalNode(value, tree, offset = 0) {
   if (typeof value === 'object') {
@@ -386,7 +387,9 @@ function unmarshalNode(value, tree, offset = 0) {
     return node;
   } else {
     const nodeTypeId = value;
-    const NodeClass = tree.language.nodeSubclasses[nodeTypeId];
+    const NodeClass = nodeTypeId === ERROR_TYPE_ID
+      ? SyntaxNode
+      : tree.language.nodeSubclasses[nodeTypeId];
     const {nodeTransferArray} = binding;
     if (nodeTransferArray[0] || nodeTransferArray[1]) {
       const result = new NodeClass(tree);
@@ -430,7 +433,7 @@ function pointToString(point) {
 function initializeLanguageNodeClasses(language) {
   const nodeTypeNamesById = binding.getNodeTypeNamesById(language);
   const nodeFieldNamesById = binding.getNodeFieldNamesById(language);
-  const nodeTypeInfo = language.nodeTypeInfo;
+  const nodeTypeInfo = language.nodeTypeInfo || [];
 
   const nodeSubclasses = [];
   for (let id = 0, n = nodeTypeNamesById.length; id < n; id++) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "index.js",
   "types": "tree-sitter.d.ts",
   "dependencies": {
-    "nan": "^2.10.0",
+    "nan": "^2.13.2",
     "prebuild-install": "^5.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter",
-  "version": "0.14.0",
+  "version": "0.15.0-0",
   "description": "Incremental parsers for node",
   "author": "Max Brunsfeld",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter",
-  "version": "0.15.0-0",
+  "version": "0.15.0-1",
   "description": "Incremental parsers for node",
   "author": "Max Brunsfeld",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chai": "3.5.x",
     "mocha": "^5.2.0",
     "superstring": "^2.3.5",
-    "tree-sitter-javascript": "0.13.x"
+    "tree-sitter-javascript": "git://github.com/tree-sitter/tree-sitter-javascript.git#node-fields"
   },
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1,5 +1,6 @@
 #include <node.h>
 #include <v8.h>
+#include "./language.h"
 #include "./node.h"
 #include "./parser.h"
 #include "./tree.h"
@@ -13,6 +14,7 @@ using namespace v8;
 void InitAll(Local<Object> exports) {
   InitConversions(exports);
   node_methods::Init(exports);
+  language_methods::Init(exports);
   Parser::Init(exports);
   Tree::Init(exports);
   TreeCursor::Init(exports);

--- a/src/language.cc
+++ b/src/language.cc
@@ -1,0 +1,85 @@
+#include "./language.h"
+#include <nan.h>
+#include <tree_sitter/api.h>
+#include <vector>
+#include <string>
+#include <v8.h>
+
+namespace node_tree_sitter {
+namespace language_methods {
+
+using std::vector;
+using namespace v8;
+
+const TSLanguage *UnwrapLanguage(const v8::Local<v8::Value> &value) {
+  if (value->IsObject()) {
+    Local<Object> arg = Local<Object>::Cast(value);
+    if (arg->InternalFieldCount() == 1) {
+      const TSLanguage *language = (const TSLanguage *)Nan::GetInternalFieldPointer(arg, 0);
+      if (language) {
+        if (ts_language_version(language) == TREE_SITTER_LANGUAGE_VERSION) {
+          return language;
+        }
+
+        std::string message = "Incompatible language version. Expected " +
+          std::to_string(TREE_SITTER_LANGUAGE_VERSION) + ". Got " +
+          std::to_string(ts_language_version(language));
+        Nan::ThrowError(Nan::RangeError(message.c_str()));
+        return nullptr;
+      }
+    }
+  }
+  Nan::ThrowTypeError("Invalid language object");
+  return nullptr;
+}
+
+static void GetNodeTypeNamesById(const Nan::FunctionCallbackInfo<Value> &info) {
+  const TSLanguage *language = UnwrapLanguage(info[0]);
+  if (!language) return;
+
+  auto result = Nan::New<Array>();
+  uint32_t length = ts_language_symbol_count(language);
+  for (uint32_t i = 0; i < length; i++) {
+    const char *name = ts_language_symbol_name(language, i);
+    TSSymbolType type = ts_language_symbol_type(language, i);
+    if (type == TSSymbolTypeRegular) {
+      result->Set(i, Nan::New(name).ToLocalChecked());
+    } else {
+      result->Set(i, Nan::Null());
+    }
+  }
+
+  info.GetReturnValue().Set(result);
+}
+
+static void GetNodeFieldNamesById(const Nan::FunctionCallbackInfo<Value> &info) {
+  const TSLanguage *language = UnwrapLanguage(info[0]);
+  if (!language) return;
+
+  auto result = Nan::New<Array>();
+  uint32_t length = ts_language_field_count(language);
+  for (uint32_t i = 0; i < length; i++) {
+    const char *name = ts_language_field_name_for_id(language, i);
+    if (name) {
+      result->Set(i, Nan::New(name).ToLocalChecked());
+    } else {
+      result->Set(i, Nan::Null());
+    }
+  }
+  info.GetReturnValue().Set(result);
+}
+
+void Init(Local<Object> exports) {
+  exports->Set(
+    Nan::New("getNodeTypeNamesById").ToLocalChecked(),
+    Nan::New<FunctionTemplate>(GetNodeTypeNamesById)->GetFunction()
+  );
+
+  exports->Set(
+    Nan::New("getNodeFieldNamesById").ToLocalChecked(),
+    Nan::New<FunctionTemplate>(GetNodeFieldNamesById)->GetFunction()
+  );
+}
+
+}  // namespace language_methods
+}  // namespace node_tree_sitter

--- a/src/language.h
+++ b/src/language.h
@@ -1,0 +1,20 @@
+#ifndef NODE_TREE_SITTER_LANGUAGE_H_
+#define NODE_TREE_SITTER_LANGUAGE_H_
+
+#include <nan.h>
+#include <v8.h>
+#include <node_object_wrap.h>
+#include <tree_sitter/api.h>
+#include "./tree.h"
+
+namespace node_tree_sitter {
+namespace language_methods {
+
+void Init(v8::Local<v8::Object>);
+
+const TSLanguage *UnwrapLanguage(const v8::Local<v8::Value> &);
+
+}  // namespace language_methods
+}  // namespace node_tree_sitter
+
+#endif  // NODE_TREE_SITTER_LANGUAGE_H_

--- a/test/node_test.js
+++ b/test/node_test.js
@@ -12,18 +12,32 @@ describe("Node", () => {
 
   describe("subclasses", () => {
     it("generates a subclass for each node type", () => {
-      const tree = parser.parse("function foo(a, b) { return a + b; }");
+      const tree = parser.parse(`
+        class A {
+          @autobind
+          @something
+          b(c, d) {
+            return c + d;
+          }
+        }
+      `);
 
-      const functionNode = tree.rootNode.child(0)
-      assert.deepEqual(functionNode.fields, ['bodyNode', 'nameNode', 'parametersNode'])
-      assert.equal(functionNode.constructor.name, 'FunctionDeclarationNode');
-      assert.equal(functionNode.nameNode.text, 'foo');
+      const classNode = tree.rootNode.firstChild;
+      assert.deepEqual(classNode.fields, ['bodyNode', 'decoratorNodes', 'nameNode'])
 
-      const paramsNode = functionNode.parametersNode;
+      const methodNode = classNode.bodyNode.firstNamedChild;
+      assert.equal(methodNode.constructor.name, 'MethodDefinitionNode');
+      assert.equal(methodNode.nameNode.text, 'b');
+      assert.deepEqual(methodNode.fields, ['bodyNode', 'decoratorNodes', 'nameNode', 'parametersNode'])
+
+      const decoratorNodes = methodNode.decoratorNodes;
+      assert.deepEqual(decoratorNodes.map(_ => _.text), ['@autobind', '@something'])
+
+      const paramsNode = methodNode.parametersNode;
       assert.equal(paramsNode.constructor.name, 'FormalParametersNode');
       assert.equal(paramsNode.namedChildren.length, 2);
 
-      const bodyNode = functionNode.bodyNode;
+      const bodyNode = methodNode.bodyNode;
       assert.equal(bodyNode.constructor.name, 'StatementBlockNode');
 
       const returnNode = bodyNode.namedChildren[0];
@@ -33,8 +47,8 @@ describe("Node", () => {
       const binaryNode = returnNode.argumentNode;
       assert.equal(binaryNode.constructor.name, 'BinaryExpressionNode');
 
-      assert.equal(binaryNode.leftNode.text, 'a')
-      assert.equal(binaryNode.rightNode.text, 'b')
+      assert.equal(binaryNode.leftNode.text, 'c')
+      assert.equal(binaryNode.rightNode.text, 'd')
       assert.equal(binaryNode.operatorNode.type, '+')
     })
   });

--- a/test/node_test.js
+++ b/test/node_test.js
@@ -10,6 +10,35 @@ describe("Node", () => {
     parser = new Parser().setLanguage(JavaScript);
   });
 
+  describe("subclasses", () => {
+    it("generates a subclass for each node type", () => {
+      const tree = parser.parse("function foo(a, b) { return a + b; }");
+
+      const functionNode = tree.rootNode.child(0)
+      assert.deepEqual(functionNode.fields, ['bodyNode', 'nameNode', 'parametersNode'])
+      assert.equal(functionNode.constructor.name, 'FunctionDeclarationNode');
+      assert.equal(functionNode.nameNode.text, 'foo');
+
+      const paramsNode = functionNode.parametersNode;
+      assert.equal(paramsNode.constructor.name, 'FormalParametersNode');
+      assert.equal(paramsNode.namedChildren.length, 2);
+
+      const bodyNode = functionNode.bodyNode;
+      assert.equal(bodyNode.constructor.name, 'StatementBlockNode');
+
+      const returnNode = bodyNode.namedChildren[0];
+      assert.deepEqual(returnNode.fields, ['argumentNode'])
+      assert.equal(returnNode.constructor.name, 'ReturnStatementNode');
+
+      const binaryNode = returnNode.argumentNode;
+      assert.equal(binaryNode.constructor.name, 'BinaryExpressionNode');
+
+      assert.equal(binaryNode.leftNode.text, 'a')
+      assert.equal(binaryNode.rightNode.text, 'b')
+      assert.equal(binaryNode.operatorNode.type, '+')
+    })
+  });
+
   describe(".children", () => {
     it("returns an array of child nodes", () => {
       const tree = parser.parse("x10 + 1000");
@@ -319,7 +348,7 @@ describe("Node", () => {
       const node = tree.rootNode;
       assert.equal(
         node.toString(),
-        '(program (expression_statement (binary_expression (number) (binary_expression (number) (ERROR) (number)))))'
+        '(program (expression_statement (binary_expression left: (number) right: (binary_expression left: (number) (ERROR) right: (number)))))'
       );
 
       const sum = node.firstChild.firstChild;
@@ -336,7 +365,7 @@ describe("Node", () => {
       const node = tree.rootNode;
       assert.equal(
         node.toString(),
-        "(program (expression_statement (parenthesized_expression (binary_expression (number) (yield_expression (MISSING))))))"
+        "(program (expression_statement (parenthesized_expression value: (binary_expression left: (number) right: (MISSING identifier)))))"
       );
 
       const sum = node.firstChild.firstChild.firstNamedChild;
@@ -344,7 +373,7 @@ describe("Node", () => {
       assert(sum.hasError());
       assert(!sum.children[0].isMissing());
       assert(!sum.children[1].isMissing());
-      assert(sum.children[2].firstChild.isMissing());
+      assert(sum.children[2].isMissing());
     });
   });
 

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -162,7 +162,7 @@ describe("Parser", () => {
 
         assert.equal(
           tree.rootNode.toString(),
-          '(program (expression_statement (call_expression (identifier) (arguments))) (expression_statement (identifier)))'
+          '(program (expression_statement (call_expression function: (identifier) arguments: (arguments))) (expression_statement (identifier)))'
         );
       })
     })
@@ -220,7 +220,7 @@ describe("Parser", () => {
       }, /Parser is in use/);
 
       const tree = await treePromise;
-      assert.equal(tree.rootNode.toString(), "(program (expression_statement (binary_expression (binary_expression (identifier) (identifier)) (identifier))))");
+      assert.equal(tree.rootNode.toString(), "(program (expression_statement (binary_expression left: (binary_expression left: (identifier) right: (identifier)) right: (identifier))))");
 
       parser.parse('a');
       parser.setLanguage(JavaScript);
@@ -281,7 +281,7 @@ describe("Parser", () => {
 
         assert.equal(
           tree.rootNode.toString(),
-          '(program (expression_statement (call_expression (identifier) (arguments))) (expression_statement (identifier)))'
+          '(program (expression_statement (call_expression function: (identifier) arguments: (arguments))) (expression_statement (identifier)))'
         );
       })
     })
@@ -294,7 +294,7 @@ describe("Parser", () => {
       const tree = parser.parseTextBufferSync(buffer);
       assert.equal(
         tree.rootNode.toString(),
-        "(program (expression_statement (binary_expression (identifier) (identifier))))"
+        "(program (expression_statement (binary_expression left: (identifier) right: (identifier))))"
       );
     });
 

--- a/test/tree_test.js
+++ b/test/tree_test.js
@@ -19,7 +19,7 @@ describe("Tree", () => {
       tree = parser.parse(input);
       assert.equal(
         tree.rootNode.toString(),
-        "(program (expression_statement (binary_expression (identifier) (identifier))))"
+        "(program (expression_statement (binary_expression left: (identifier) right: (identifier))))"
       );
 
       const sumNode = tree.rootNode.firstChild.firstChild;
@@ -42,7 +42,7 @@ describe("Tree", () => {
       tree = parser.parse(input, tree);
       assert.equal(
         tree.rootNode.toString(),
-        "(program (expression_statement (binary_expression (binary_expression (identifier) (identifier)) (identifier))))"
+        "(program (expression_statement (binary_expression left: (binary_expression left: (identifier) right: (identifier)) right: (identifier))))"
       );
     });
 
@@ -52,7 +52,7 @@ describe("Tree", () => {
       tree = parser.parse(input);
       assert.equal(
         tree.rootNode.toString(),
-        "(program (expression_statement (binary_expression (identifier) (identifier))))"
+        "(program (expression_statement (binary_expression left: (identifier) right: (identifier))))"
       );
 
       const variableNode = tree.rootNode.firstChild.firstChild.lastChild;
@@ -66,7 +66,7 @@ describe("Tree", () => {
       tree = parser.parse(input, tree);
       assert.equal(
         tree.rootNode.toString(),
-        "(program (expression_statement (binary_expression (binary_expression (identifier) (identifier)) (identifier))))"
+        "(program (expression_statement (binary_expression left: (binary_expression left: (identifier) right: (identifier)) right: (identifier))))"
       );
     });
   });
@@ -112,7 +112,7 @@ describe("Tree", () => {
 
       assert.equal(
         tree1.rootNode.toString(),
-        "(program (expression_statement (binary_expression (identifier) (identifier))))"
+        "(program (expression_statement (binary_expression left: (identifier) right: (identifier))))"
       );
 
       sourceCode = "abc + defg + hij";
@@ -128,7 +128,7 @@ describe("Tree", () => {
       const tree2 = parser.parse(sourceCode, tree1);
       assert.equal(
         tree2.rootNode.toString(),
-        "(program (expression_statement (binary_expression (binary_expression (identifier) (identifier)) (identifier))))"
+        "(program (expression_statement (binary_expression left: (binary_expression left: (identifier) right: (identifier)) right: (identifier))))"
       );
 
       const ranges = tree1.getChangedRanges(tree2);


### PR DESCRIPTION
This PR exposes the new *node fields* APIs introduced in https://github.com/tree-sitter/tree-sitter/pull/271.

When using a language that includes fields (like these branches of [tree-sitter-javascript](https://github.com/tree-sitter/tree-sitter-javascript/pull/96), [tree-sitter-python](https://github.com/tree-sitter/tree-sitter-python/pull/39) and [tree-sitter-bash](https://github.com/tree-sitter/tree-sitter-bash/pull/43)), syntax tree nodes will have different subclasses. Each node will have getters for its different fields.

Example:

```js
const tree = parser.parse(`
  class A {
    @autobind
    @something
    b(c, d) {
      return c + d;
    }
  }
`);

const classNode = tree.rootNode.firstChild;
const methodNode = classNode.bodyNode.firstNamedChild;

// Subclasses named after the node types
assert.equal(classNode.constructor.name, 'ClassDeclarationNode');
assert.equal(methodNode.constructor.name, 'MethodDefinitionNode');

// Plural getters that return arrays
const decoratorNodes = methodNode.decoratorNodes;
assert.deepEqual(decoratorNodes.map(_ => _.text), ['@autobind', '@something'])

// Singular getters that return single nodes
const paramsNode = methodNode.parametersNode;
const bodyNode = methodNode.bodyNode;
assert.equal(paramsNode.constructor.name, 'FormalParametersNode');
assert.equal(bodyNode.constructor.name, 'StatementBlockNode');
```