### PR TITLE
Target submodule to avoid using clock_gettime on macOS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/tree-sitter"]
 	path = vendor/tree-sitter
-	url = https://github.com/maxbrunsfeld/tree-sitter.git
+	url = https://github.com/atom/tree-sitter.git


### PR DESCRIPTION
This PR changes the submodule for `tree-sitter` to point to the `atom` fork (more specifically https://github.com/atom/tree-sitter/tree/node-tree-sitter-submodule).

This branch contains a cherry-pick of https://github.com/tree-sitter/tree-sitter/pull/361 on top of https://github.com/tree-sitter/tree-sitter/commit/77636e8fe6418c10a1c2ddb7a278c886bff7ef35 (which is the commit that's currently used by the submodule on `node-tree-sitter`).

