### PR TITLE
Use clang for linux travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,14 @@ matrix:
   include:
   - os: osx
   - os: linux
-    compiler: gcc
     env:
-      - CXX="g++-4.9"
-      - CC="gcc-4.9"
+      - CXX=clang++
+      - CC=clang
     addons:
       apt:
-        sources:
-        - ubuntu-toolchain-r-test
         packages:
-        - gcc-4.9
-        - g++-4.9
+        - build-essential
+        - clang-3.3
 
 before_install:
 - git submodule update --init --recursive


### PR DESCRIPTION
The Linux binaries that are created on Travis are causing problems for the Atom build. For the last two releases, I've had to delete the prebuilt Linux binaries in order to get the Atom Travis builds to pass.

I think the problem may be that these binaries are compiled with gcc. Atom [uses clang](https://github.com/atom/atom/blob/7aaf836c0da01fb55a48caf152d636e8d76dec3f/.travis.yml#L19), and [so does `node-keytar`](https://github.com/atom/node-keytar/blob/35b90d11acf9142e1c589668df9095fa0bde9236/.travis.yml#L10), Atom's other native dependency with `prebuild` support. Clang and gcc create binaries with dependencies on two different C++ standard library implementations.

For now, I'm going to switch the `node-tree-sitter` builds to also use clang on Linux. Hopefully this ends up working for all Linux users. If it ends up breaking people with gcc, we're going to have to just stop using prebuild at all on Linux.

/cc @wingrunr21  @rafeca @nathansobo 