### PR TITLE
Prebuild against 4.0.4 and 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",
-    "prebuild": "prebuild -r electron -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 --strip && prebuild -t 8.16.0 -t 9.11.2 -t 10.12.0 --strip",
+    "prebuild": "prebuild -r electron -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 -t 4.0.4 -t 5.0.0 --strip && prebuild -t 8.16.0 -t 9.11.2 -t 10.12.0 --strip",
     "prebuild:upload": "prebuild --upload-all",
     "test": "mocha"
   }


### PR DESCRIPTION
This is to match tree-sitter/tree-sitter-ruby#108

Happy to drop support for < 4.0 like we did there as well.

Note I'm currently working on the WASM move but need a few PRs in tree-sitter proper to land first.