### PR TITLE
Add bufferSize and includedRanges options to parse function in TS def

### DIFF
--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -1,6 +1,6 @@
 declare module "tree-sitter" {
   class Parser {
-    parse(input: string | Parser.Input, previousTree?: Parser.Tree): Parser.Tree;
+    parse(input: string | Parser.Input, previousTree?: Parser.Tree, options?: {bufferSize?: number, includedRanges?: Parser.Range[]}): Parser.Tree;
     getLanguage(): any;
     setLanguage(language: any): void;
     getLogger(): Parser.Logger;

--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -14,8 +14,10 @@ declare module "tree-sitter" {
     };
 
     export type Range = {
-      start: Point;
-      end: Point;
+      startIndex: number,
+      endIndex: number,
+      startPosition: Point,
+      endPosition: Point
     };
 
     export type Edit = {


### PR DESCRIPTION
The function signature of `Parser.prototype.parse` defined in `index.js`
```JS
Parser.prototype.parse = function(input, oldTree, {bufferSize, includedRanges}={})
```
accepts a third optional parameter.
This commit reflects the signature in TypeScript definition.

depends on #64 