### PR TITLE
Fix the TypeScript definition of a Range

### DIFF
--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -14,8 +14,10 @@ declare module "tree-sitter" {
     };
 
     export type Range = {
-      start: Point;
-      end: Point;
+      startIndex: number,
+      endIndex: number,
+      startPosition: Point,
+      endPosition: Point
     };
 
     export type Edit = {


### PR DESCRIPTION
A Range contains:
- `startIndex`
- `endIndex`
- `startPosition`
- `endPosition`

