### PR TITLE
Fix #53: Illegal Invocation in jest tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,16 +16,17 @@ const {Query, Parser, NodeMethods, Tree, TreeCursor} = binding;
  * Tree
  */
 
-const {rootNode, edit} = Tree.prototype;
+const {_rootNode, _edit} = Tree.prototype;
 
 Object.defineProperty(Tree.prototype, 'rootNode', {
   get() {
-    return unmarshalNode(rootNode.call(this), this);
-  }
+    return unmarshalNode(_rootNode.call(this), this);
+  },
+  configurable: true
 });
 
 Tree.prototype.edit = function(arg) {
-  edit.call(
+  _edit.call(
     this,
     arg.startPosition.row, arg.startPosition.column,
     arg.oldEndPosition.row, arg.oldEndPosition.column,
@@ -340,36 +341,34 @@ Parser.prototype.parseTextBufferSync = function(buffer, oldTree, {includedRanges
  * TreeCursor
  */
 
-const {startPosition, endPosition, currentNode, reset} = TreeCursor.prototype;
+const {_startPosition, _endPosition, _currentNode, _reset} = TreeCursor.prototype;
 
 Object.defineProperties(TreeCursor.prototype, {
   currentNode: {
     get() {
-      return unmarshalNode(currentNode.call(this), this.tree);
-    }
+      return unmarshalNode(_currentNode.call(this), this.tree);
+    },
+    configurable: true,
   },
   startPosition: {
     get() {
-      startPosition.call(this);
+      _startPosition.call(this);
       return unmarshalPoint();
-    }
+    },
+    configurable: true,
   },
   endPosition: {
     get() {
-      endPosition.call(this);
+      _endPosition.call(this);
       return unmarshalPoint();
-    }
+    },
+    configurable: true,
   },
-  nodeText: {
-    get() {
-      return this.tree.getText(this)
-    }
-  }
 });
 
 TreeCursor.prototype.reset = function(node) {
   marshalNode(node);
-  reset.call(this);
+  _reset.call(this);
 }
 
 /*

--- a/jest-tests/dothings.js
+++ b/jest-tests/dothings.js
@@ -1,0 +1,9 @@
+const Parser = require("..");
+const Javascript = require("tree-sitter-javascript");
+const jsParser = new Parser();
+jsParser.setLanguage(Javascript);
+
+module.exports = (input) => {
+  const code = jsParser.parse(input)
+  return code.rootNode;
+}

--- a/jest-tests/test.test.js
+++ b/jest-tests/test.test.js
@@ -1,0 +1,203 @@
+const Parser = require("..");
+const dothings = require("./dothings");
+const Javascript = require("tree-sitter-javascript");
+
+const { Query } = Parser;
+const jsParser = new Parser();
+jsParser.setLanguage(Javascript);
+
+const input = `
+const Parser = require(".");
+const Javascript = require("tree-sitter-javascript");
+const jsParser = new Parser();
+`;
+const output =
+  "(program (lexical_declaration (variable_declarator name: (identifier) value: (call_expression function: (identifier) arguments: (arguments (string))))) (lexical_declaration (variable_declarator name: (identifier) value: (call_expression function: (identifier) arguments: (arguments (string))))) (lexical_declaration (variable_declarator name: (identifier) value: (new_expression constructor: (identifier) arguments: (arguments)))))";
+describe("Jest test 1", () => {
+  it("should work", () => {
+    const code = jsParser.parse(input);
+    const output = code.rootNode.toString();
+    expect(output).toBe(output);
+  });
+
+  it("should work with separate import", () => {
+    expect(dothings(input).toString()).toBe(output);
+  });
+  function assertCursorState(cursor, params) {
+    expect(cursor.nodeType).toBe(params.nodeType);
+    expect(cursor.nodeIsNamed).toBe(params.nodeIsNamed);
+    expect(cursor.startPosition).toEqual(params.startPosition);
+    expect(cursor.endPosition).toEqual(params.endPosition);
+    expect(cursor.startIndex).toEqual(params.startIndex);
+    expect(cursor.endIndex).toEqual(params.endIndex);
+
+    const node = cursor.currentNode;
+    expect(node.type).toBe(params.nodeType);
+    expect(node.isNamed).toBe(params.nodeIsNamed);
+    expect(node.startPosition).toEqual(params.startPosition);
+    expect(node.endPosition).toEqual(params.endPosition);
+    expect(node.startIndex).toEqual(params.startIndex);
+    expect(node.endIndex).toEqual(params.endIndex);
+  }
+
+  function assert(thing) {
+    expect(thing).toBeTruthy();
+  }
+
+  it("should work with cursors", () => {
+    const tree = jsParser.parse("a * b + c / d");
+
+    const cursor = tree.walk();
+    assertCursorState(cursor, {
+      nodeType: "program",
+      nodeIsNamed: true,
+      startPosition: { row: 0, column: 0 },
+      endPosition: { row: 0, column: 13 },
+      startIndex: 0,
+      endIndex: 13,
+    });
+
+    assert(cursor.gotoFirstChild());
+    assertCursorState(cursor, {
+      nodeType: "expression_statement",
+      nodeIsNamed: true,
+      startPosition: { row: 0, column: 0 },
+      endPosition: { row: 0, column: 13 },
+      startIndex: 0,
+      endIndex: 13,
+    });
+
+    assert(cursor.gotoFirstChild());
+    assertCursorState(cursor, {
+      nodeType: "binary_expression",
+      nodeIsNamed: true,
+      startPosition: { row: 0, column: 0 },
+      endPosition: { row: 0, column: 13 },
+      startIndex: 0,
+      endIndex: 13,
+    });
+
+    assert(cursor.gotoFirstChild());
+    assertCursorState(cursor, {
+      nodeType: "binary_expression",
+      nodeIsNamed: true,
+      startPosition: { row: 0, column: 0 },
+      endPosition: { row: 0, column: 5 },
+      startIndex: 0,
+      endIndex: 5,
+    });
+
+    assert(cursor.gotoFirstChild());
+    assertCursorState(cursor, {
+      nodeType: "identifier",
+      nodeIsNamed: true,
+      startPosition: { row: 0, column: 0 },
+      endPosition: { row: 0, column: 1 },
+      startIndex: 0,
+      endIndex: 1,
+    });
+
+    assert(!cursor.gotoFirstChild());
+    assert(cursor.gotoNextSibling());
+    assertCursorState(cursor, {
+      nodeType: "*",
+      nodeIsNamed: false,
+      startPosition: { row: 0, column: 2 },
+      endPosition: { row: 0, column: 3 },
+      startIndex: 2,
+      endIndex: 3,
+    });
+
+    assert(cursor.gotoNextSibling());
+    assertCursorState(cursor, {
+      nodeType: "identifier",
+      nodeIsNamed: true,
+      startPosition: { row: 0, column: 4 },
+      endPosition: { row: 0, column: 5 },
+      startIndex: 4,
+      endIndex: 5,
+    });
+
+    assert(!cursor.gotoNextSibling());
+    assert(cursor.gotoParent());
+    assertCursorState(cursor, {
+      nodeType: "binary_expression",
+      nodeIsNamed: true,
+      startPosition: { row: 0, column: 0 },
+      endPosition: { row: 0, column: 5 },
+      startIndex: 0,
+      endIndex: 5,
+    });
+
+    assert(cursor.gotoNextSibling());
+    assertCursorState(cursor, {
+      nodeType: "+",
+      nodeIsNamed: false,
+      startPosition: { row: 0, column: 6 },
+      endPosition: { row: 0, column: 7 },
+      startIndex: 6,
+      endIndex: 7,
+    });
+
+    assert(cursor.gotoNextSibling());
+    assertCursorState(cursor, {
+      nodeType: "binary_expression",
+      nodeIsNamed: true,
+      startPosition: { row: 0, column: 8 },
+      endPosition: { row: 0, column: 13 },
+      startIndex: 8,
+      endIndex: 13,
+    });
+
+    const childIndex = cursor.gotoFirstChildForIndex(12);
+    assertCursorState(cursor, {
+      nodeType: "identifier",
+      nodeIsNamed: true,
+      startPosition: { row: 0, column: 12 },
+      endPosition: { row: 0, column: 13 },
+      startIndex: 12,
+      endIndex: 13,
+    });
+    expect(childIndex).toBe(2);
+
+    assert(!cursor.gotoNextSibling());
+    assert(cursor.gotoParent());
+    assert(cursor.gotoParent());
+    assert(cursor.gotoParent());
+    assert(cursor.gotoParent());
+    assert(!cursor.gotoParent());
+  });
+
+  it("returns all of the matches for the given query", () => {
+    const tree = jsParser.parse("function one() { two(); function three() {} }");
+    const query = new Query(
+      Javascript,
+      `
+    (function_declaration name: (identifier) @fn-def)
+    (call_expression function: (identifier) @fn-ref)
+  `
+    );
+    const matches = query.matches(tree.rootNode);
+    expect(formatMatches(tree, matches)).toEqual([
+      { pattern: 0, captures: [{ name: "fn-def", text: "one" }] },
+      { pattern: 1, captures: [{ name: "fn-ref", text: "two" }] },
+      { pattern: 0, captures: [{ name: "fn-def", text: "three" }] },
+    ]);
+  });
+});
+
+function formatMatches(tree, matches) {
+  return matches.map(({ pattern, captures }) => ({
+    pattern,
+    captures: formatCaptures(tree, captures),
+  }));
+}
+
+function formatCaptures(tree, captures) {
+  return captures.map((c) => {
+    const node = c.node;
+    delete c.node;
+    c.text = tree.getText(node);
+    return c;
+  });
+}

--- a/jest-tests/test2.test.js
+++ b/jest-tests/test2.test.js
@@ -1,0 +1,16 @@
+const Parser = require("..");
+const Javascript = require("tree-sitter-javascript");
+const jsParser = new Parser();
+jsParser.setLanguage(Javascript);
+
+describe("Jest test 1", () => {
+  it("should work", () => {
+    const code = jsParser.parse(`
+    const Parser = require(".");
+    const Javascript = require("tree-sitter-javascript");
+    const jsParser = new Parser();
+    `)
+    const output = code.rootNode.toString()
+    expect(output).toBe('(program (lexical_declaration (variable_declarator name: (identifier) value: (call_expression function: (identifier) arguments: (arguments (string))))) (lexical_declaration (variable_declarator name: (identifier) value: (call_expression function: (identifier) arguments: (arguments (string))))) (lexical_declaration (variable_declarator name: (identifier) value: (new_expression constructor: (identifier) arguments: (arguments)))))');
+  })
+})

--- a/jest-tests/test3.test.js
+++ b/jest-tests/test3.test.js
@@ -1,0 +1,27 @@
+const Parser = require("..");
+const Javascript = require("tree-sitter-javascript");
+
+describe("Jest test 1", () => {
+  it("should work", () => {
+    const jsParser = new Parser();
+    jsParser.setLanguage(Javascript);
+    const code = jsParser.parse(`
+    const Parser = require(".");
+    const Javascript = require("tree-sitter-javascript");
+    const jsParser = new Parser();
+    `)
+    const output = code.rootNode.toString()
+    expect(output).toBe('(program (lexical_declaration (variable_declarator name: (identifier) value: (call_expression function: (identifier) arguments: (arguments (string))))) (lexical_declaration (variable_declarator name: (identifier) value: (call_expression function: (identifier) arguments: (arguments (string))))) (lexical_declaration (variable_declarator name: (identifier) value: (new_expression constructor: (identifier) arguments: (arguments)))))');
+  })
+  it("should work", () => {
+    const jsParser = new Parser();
+    jsParser.setLanguage(Javascript);
+    const code = jsParser.parse(`
+    const Parser = require(".");
+    const Javascript = require("tree-sitter-javascript");
+    const jsParser = new Parser();
+    `)
+    const output = code.rootNode.toString()
+    expect(output).toBe('(program (lexical_declaration (variable_declarator name: (identifier) value: (call_expression function: (identifier) arguments: (arguments (string))))) (lexical_declaration (variable_declarator name: (identifier) value: (call_expression function: (identifier) arguments: (arguments (string))))) (lexical_declaration (variable_declarator name: (identifier) value: (new_expression constructor: (identifier) arguments: (arguments)))))');
+  })
+})

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "chai": "3.5.x",
+    "jest": "^26.6.3",
     "mocha": "^5.2.0",
     "prebuild": "^7.6.0",
     "superstring": "^2.4.2",
@@ -30,6 +31,6 @@
     "build": "node-gyp build",
     "prebuild": "prebuild -r electron -t 3.0.0 -t 4.0.0 -t 4.0.4 -t 5.0.0 --strip && prebuild -t 10.12.0 -t 12.13.0 --strip",
     "prebuild:upload": "prebuild --upload-all",
-    "test": "mocha"
+    "test": "mocha && jest"
   }
 }

--- a/runit.js
+++ b/runit.js
@@ -1,0 +1,12 @@
+const Parser = require(".");
+const Javascript = require("tree-sitter-javascript");
+const jsParser = new Parser();
+jsParser.setLanguage(Javascript);
+
+const code = jsParser.parse(`
+const Parser = require(".");
+const Javascript = require("tree-sitter-javascript");
+const jsParser = new Parser();
+`)
+const output = code.rootNode.toString()
+console.log(output);

--- a/src/tree.cc
+++ b/src/tree.cc
@@ -22,8 +22,8 @@ void Tree::Init(Local<Object> exports) {
   tpl->SetClassName(class_name);
 
   FunctionPair methods[] = {
-    {"edit", Edit},
-    {"rootNode", RootNode},
+    {"_edit", Edit},
+    {"_rootNode", RootNode},
     {"printDotGraph", PrintDotGraph},
     {"getChangedRanges", GetChangedRanges},
     {"getEditedRange", GetEditedRange},

--- a/src/tree_cursor.cc
+++ b/src/tree_cursor.cc
@@ -28,14 +28,14 @@ void TreeCursor::Init(v8::Local<v8::Object> exports) {
   };
 
   FunctionPair methods[] = {
-    {"startPosition", StartPosition},
-    {"endPosition", EndPosition},
+    {"_startPosition", StartPosition},
+    {"_endPosition", EndPosition},
     {"gotoParent", GotoParent},
     {"gotoFirstChild", GotoFirstChild},
     {"gotoFirstChildForIndex", GotoFirstChildForIndex},
     {"gotoNextSibling", GotoNextSibling},
-    {"currentNode", CurrentNode},
-    {"reset", Reset},
+    {"_currentNode", CurrentNode},
+    {"_reset", Reset},
   };
 
   for (size_t i = 0; i < length_of_array(getters); i++) {


### PR DESCRIPTION
Fix #53

This fixes the illegal invocation. Basically, the problem described in https://stackoverflow.com/questions/9677985/uncaught-typeerror-illegal-invocation-in-chrome is what is happening here, but it appears to be a race condition.

When we re-load the context in the same process (which happens with Jest's worker pool), the getter is triggered, for no apparent reason, BEFORE the native extension has had a chance to load. `this` is actually the user-land object, with no knowledge of the native prototype yet. Just by changing the name of the extension's getters, it fixes this race condition.

I've added Jest and 3 simple jest tests, all of which failed before the change (you're welcome to try them against master to see what I mean)