### PR TITLE
fix: prevent Nan::Utf8String destructor call due to out of scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.31",
-    "chai": "3.5.x",
-    "mocha": "^5.2.0",
+    "chai": "^4.3.3",
+    "mocha": "^8.3.1",
     "prebuild": "^10.0.1",
     "superstring": "^2.4.2",
     "tree-sitter-javascript": "git://github.com/tree-sitter/tree-sitter-javascript.git#master"

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
   "types": "tree-sitter.d.ts",
   "dependencies": {
     "nan": "^2.14.0",
-    "prebuild-install": "^5.0.0"
+    "prebuild-install": "^6.0.1"
   },
   "devDependencies": {
     "@types/node": "^14.14.31",
     "chai": "3.5.x",
     "mocha": "^5.2.0",
-    "prebuild": "^7.6.0",
+    "prebuild": "^10.0.1",
     "superstring": "^2.4.2",
     "tree-sitter-javascript": "git://github.com/tree-sitter/tree-sitter-javascript.git#master"
   },

--- a/src/query.cc
+++ b/src/query.cc
@@ -95,6 +95,7 @@ void Query::New(const Nan::FunctionCallbackInfo<Value> &info) {
   uint32_t source_len;
   uint32_t error_offset = 0;
   TSQueryError error_type = TSQueryErrorNone;
+  TSQuery *query;
 
   if (language == nullptr) {
     Nan::ThrowError("Missing language argument");
@@ -103,20 +104,20 @@ void Query::New(const Nan::FunctionCallbackInfo<Value> &info) {
 
   if (info[1]->IsString()) {
     auto string = Nan::To<String> (info[1]).ToLocalChecked();
-    source = *Nan::Utf8String(string);
-    source_len = string->Length();
+    Nan::Utf8String utf8_string(string);
+    source = *utf8_string;
+    source_len = utf8_string.length();
+    query = ts_query_new(language, source, source_len, &error_offset, &error_type);
   }
   else if (node::Buffer::HasInstance(info[1])) {
     source = node::Buffer::Data(info[1]);
     source_len = node::Buffer::Length(info[1]);
+    query = ts_query_new(language, source, source_len, &error_offset, &error_type);
   }
   else {
     Nan::ThrowError("Missing source argument");
     return;
   }
-
-  TSQuery *query = ts_query_new(
-      language, source, source_len, &error_offset, &error_type);
 
   if (error_offset > 0) {
     const char *error_name = query_error_names[error_type];


### PR DESCRIPTION
Fixes #72
This PR resolves the issue due to automatic `Nan::Utf8String` destructor call due to outing of scope on line [108](https://github.com/tree-sitter/node-tree-sitter/compare/master...ahlinc:fix/segmentation-fault/72?expand=1#diff-5df376ef3534aee11e2e44e6e42e8e90da079dd96ac7da487a99bc6653366fdcL108) what leads to:
```
source == "\0"
source_len > 0
```
so `ts_query_new` function would try to read a lot of bytes from a string contained in the destructed `Nan::Utf8String` object whose memory is most likely to be freed already in case of a long input string.

