### PR TITLE
Use C++14 to allow building for Electron 11 on MacOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -31,7 +31,7 @@
         "-std=c++0x",
       ],
       'xcode_settings': {
-        'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
+        'CLANG_CXX_LANGUAGE_STANDARD': 'c++14',
       },
     },
     {


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/node-tree-sitter/issues/82.