### PR TITLE
Use the new ArrayBuffer API for Electron 13

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -49,4 +49,8 @@
       ]
     }
   ],
+  'variables': { 'runtime%': 'node' },
+  'conditions': [
+      ['runtime=="electron"', { 'defines': ['NODE_RUNTIME_ELECTRON=1'] }],
+  ]
 }

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -28,8 +28,14 @@ void InitConversions(Local<Object> exports) {
   end_position_key.Reset(Nan::Persistent<String>(Nan::New("endPosition").ToLocalChecked()));
 
   point_transfer_buffer = static_cast<uint32_t *>(malloc(2 * sizeof(uint32_t)));
+
+  #if V8_MAJOR_VERSION >= 8
   auto backing_store = ArrayBuffer::NewBackingStore(point_transfer_buffer, 2 * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
   auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
+  #else
+  auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), point_transfer_buffer, 2 * sizeof(uint32_t));
+  #endif
+
   Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), Uint32Array::New(js_point_transfer_buffer, 0, 2));
 }
 

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -28,7 +28,8 @@ void InitConversions(Local<Object> exports) {
   end_position_key.Reset(Nan::Persistent<String>(Nan::New("endPosition").ToLocalChecked()));
 
   point_transfer_buffer = static_cast<uint32_t *>(malloc(2 * sizeof(uint32_t)));
-  auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), point_transfer_buffer, 2 * sizeof(uint32_t));
+  auto backing_store = ArrayBuffer::NewBackingStore(point_transfer_buffer, 2 * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
+  auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
   Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), Uint32Array::New(js_point_transfer_buffer, 0, 2));
 }
 

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -29,11 +29,16 @@ void InitConversions(Local<Object> exports) {
 
   point_transfer_buffer = static_cast<uint32_t *>(malloc(2 * sizeof(uint32_t)));
 
-  #if V8_MAJOR_VERSION >= 8
-  auto backing_store = ArrayBuffer::NewBackingStore(point_transfer_buffer, 2 * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
-  auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
+  #if _MSC_VER && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
+    // this is a terrible thing we have to do because of https://github.com/electron/electron/issues/29893
+    v8::Local<v8::Object> bufferView;
+    bufferView = node::Buffer::New(Isolate::GetCurrent(), point_transfer_buffer, 0, 2 * sizeof(uint32_t)).ToLocalChecked();
+    auto js_point_transfer_buffer = node::Buffer::Data(bufferView);
+  #elif V8_MAJOR_VERSION >= 8
+    auto backing_store = ArrayBuffer::NewBackingStore(point_transfer_buffer, 2 * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
+    auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
   #else
-  auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), point_transfer_buffer, 2 * sizeof(uint32_t));
+    auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), point_transfer_buffer, 2 * sizeof(uint32_t));
   #endif
 
   Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), Uint32Array::New(js_point_transfer_buffer, 0, 2));

--- a/src/node.cc
+++ b/src/node.cc
@@ -29,7 +29,8 @@ static inline void setup_transfer_buffer(uint32_t node_count) {
     }
     transfer_buffer_length = new_length;
     transfer_buffer = static_cast<uint32_t *>(malloc(transfer_buffer_length * sizeof(uint32_t)));
-    auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer, transfer_buffer_length * sizeof(uint32_t));
+    auto backing_store = ArrayBuffer::NewBackingStore(transfer_buffer, transfer_buffer_length * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
+    auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
     Nan::Set(
       Nan::New(module_exports),
       Nan::New("nodeTransferArray").ToLocalChecked(),

--- a/src/node.cc
+++ b/src/node.cc
@@ -29,8 +29,14 @@ static inline void setup_transfer_buffer(uint32_t node_count) {
     }
     transfer_buffer_length = new_length;
     transfer_buffer = static_cast<uint32_t *>(malloc(transfer_buffer_length * sizeof(uint32_t)));
+
+    #if V8_MAJOR_VERSION >= 8
     auto backing_store = ArrayBuffer::NewBackingStore(transfer_buffer, transfer_buffer_length * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
     auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
+    #else
+    auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer, transfer_buffer_length * sizeof(uint32_t));
+    #endif
+
     Nan::Set(
       Nan::New(module_exports),
       Nan::New("nodeTransferArray").ToLocalChecked(),

--- a/src/node.cc
+++ b/src/node.cc
@@ -30,11 +30,16 @@ static inline void setup_transfer_buffer(uint32_t node_count) {
     transfer_buffer_length = new_length;
     transfer_buffer = static_cast<uint32_t *>(malloc(transfer_buffer_length * sizeof(uint32_t)));
 
-    #if V8_MAJOR_VERSION >= 8
-    auto backing_store = ArrayBuffer::NewBackingStore(transfer_buffer, transfer_buffer_length * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
-    auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
+    #if _MSC_VER && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
+      // this is a terrible thing we have to do because of https://github.com/electron/electron/issues/29893
+      v8::Local<v8::Object> bufferView;
+      bufferView = node::Buffer::New(Isolate::GetCurrent(), transfer_buffer, 0, transfer_buffer_length * sizeof(uint32_t)).ToLocalChecked();
+      auto js_point_transfer_buffer = node::Buffer::Data(bufferView);
+    #elif V8_MAJOR_VERSION >= 8
+      auto backing_store = ArrayBuffer::NewBackingStore(transfer_buffer, transfer_buffer_length * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
+      auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
     #else
-    auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer, transfer_buffer_length * sizeof(uint32_t));
+      auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer, transfer_buffer_length * sizeof(uint32_t));
     #endif
 
     Nan::Set(


### PR DESCRIPTION
Changed the ArrayBuffer API to use new way so it compiles on Node 14+