### PR TITLE
feat: expose nodeIsMissing getter

### DIFF
--- a/src/tree_cursor.cc
+++ b/src/tree_cursor.cc
@@ -24,6 +24,7 @@ void TreeCursor::Init(v8::Local<v8::Object> exports) {
     {"endIndex", EndIndex},
     {"nodeType", NodeType},
     {"nodeIsNamed", NodeIsNamed},
+    {"nodeIsMissing", NodeIsMissing},
     {"currentFieldName", CurrentFieldName},
   };
 
@@ -146,6 +147,13 @@ void TreeCursor::NodeIsNamed(v8::Local<v8::String> prop, const Nan::PropertyCall
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
 
   info.GetReturnValue().Set(Nan::New(ts_node_is_named(node)));
+}
+
+void TreeCursor::NodeIsMissing(v8::Local<v8::String> prop, const Nan::PropertyCallbackInfo<v8::Value> &info) {
+  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+  TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
+
+  info.GetReturnValue().Set(Nan::New(ts_node_is_missing(node)));
 }
 
 void TreeCursor::CurrentFieldName(v8::Local<v8::String> prop, const Nan::PropertyCallbackInfo<v8::Value> &info) {

--- a/src/tree_cursor.h
+++ b/src/tree_cursor.h
@@ -29,6 +29,7 @@ class TreeCursor : public Nan::ObjectWrap {
 
   static void NodeType(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
   static void NodeIsNamed(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
+  static void NodeIsMissing(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
   static void CurrentFieldName(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
   static void StartIndex(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
   static void EndIndex(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);

--- a/test/tree_test.js
+++ b/test/tree_test.js
@@ -159,6 +159,7 @@ describe("Tree", () => {
       assertCursorState(cursor, {
         nodeType: 'program',
         nodeIsNamed: true,
+        nodeIsMissing: false,
         startPosition: {row: 0, column: 0},
         endPosition: {row: 0, column: 13},
         startIndex: 0,
@@ -169,6 +170,7 @@ describe("Tree", () => {
       assertCursorState(cursor, {
         nodeType: 'expression_statement',
         nodeIsNamed: true,
+        nodeIsMissing: false,
         startPosition: {row: 0, column: 0},
         endPosition: {row: 0, column: 13},
         startIndex: 0,
@@ -179,6 +181,7 @@ describe("Tree", () => {
       assertCursorState(cursor, {
         nodeType: 'binary_expression',
         nodeIsNamed: true,
+        nodeIsMissing: false,
         startPosition: {row: 0, column: 0},
         endPosition: {row: 0, column: 13},
         startIndex: 0,
@@ -189,6 +192,7 @@ describe("Tree", () => {
       assertCursorState(cursor, {
         nodeType: 'binary_expression',
         nodeIsNamed: true,
+        nodeIsMissing: false,
         startPosition: {row: 0, column: 0},
         endPosition: {row: 0, column: 5},
         startIndex: 0,
@@ -199,6 +203,7 @@ describe("Tree", () => {
       assertCursorState(cursor, {
         nodeType: 'identifier',
         nodeIsNamed: true,
+        nodeIsMissing: false,
         startPosition: {row: 0, column: 0},
         endPosition: {row: 0, column: 1},
         startIndex: 0,
@@ -210,6 +215,7 @@ describe("Tree", () => {
       assertCursorState(cursor, {
         nodeType: '*',
         nodeIsNamed: false,
+        nodeIsMissing: false,
         startPosition: {row: 0, column: 2},
         endPosition: {row: 0, column: 3},
         startIndex: 2,
@@ -220,6 +226,7 @@ describe("Tree", () => {
       assertCursorState(cursor, {
         nodeType: 'identifier',
         nodeIsNamed: true,
+        nodeIsMissing: false,
         startPosition: {row: 0, column: 4},
         endPosition: {row: 0, column: 5},
         startIndex: 4,
@@ -231,6 +238,7 @@ describe("Tree", () => {
       assertCursorState(cursor, {
         nodeType: 'binary_expression',
         nodeIsNamed: true,
+        nodeIsMissing: false,
         startPosition: {row: 0, column: 0},
         endPosition: {row: 0, column: 5},
         startIndex: 0,
@@ -241,6 +249,7 @@ describe("Tree", () => {
       assertCursorState(cursor, {
         nodeType: '+',
         nodeIsNamed: false,
+        nodeIsMissing: false,
         startPosition: {row: 0, column: 6},
         endPosition: {row: 0, column: 7},
         startIndex: 6,
@@ -251,6 +260,7 @@ describe("Tree", () => {
       assertCursorState(cursor, {
         nodeType: 'binary_expression',
         nodeIsNamed: true,
+        nodeIsMissing: false,
         startPosition: {row: 0, column: 8},
         endPosition: {row: 0, column: 13},
         startIndex: 8,
@@ -261,6 +271,7 @@ describe("Tree", () => {
       assertCursorState(cursor, {
         nodeType: 'identifier',
         nodeIsNamed: true,
+        nodeIsMissing: false,
         startPosition: {row: 0, column: 12},
         endPosition: {row: 0, column: 13},
         startIndex: 12,
@@ -285,6 +296,7 @@ describe("Tree", () => {
       assertCursorState(cursor, {
         nodeType: 'binary_expression',
         nodeIsNamed: true,
+        nodeIsMissing: false,
         startPosition: {row: 0, column: 0},
         endPosition: {row: 0, column: 5},
         startIndex: 0,
@@ -295,6 +307,7 @@ describe("Tree", () => {
       assertCursorState(cursor, {
         nodeType: 'identifier',
         nodeIsNamed: true,
+        nodeIsMissing: false,
         startPosition: {row: 0, column: 0},
         endPosition: {row: 0, column: 1},
         startIndex: 0,
@@ -308,8 +321,12 @@ describe("Tree", () => {
 });
 
 function assertCursorState(cursor, params) {
+  assert.isBoolean(cursor.nodeIsNamed);
+  assert.isBoolean(cursor.nodeIsMissing);
+
   assert.equal(cursor.nodeType, params.nodeType);
   assert.equal(cursor.nodeIsNamed, params.nodeIsNamed);
+  assert.equal(cursor.nodeIsMissing, params.nodeIsMissing);
   assert.deepEqual(cursor.startPosition, params.startPosition);
   assert.deepEqual(cursor.endPosition, params.endPosition);
   assert.deepEqual(cursor.startIndex, params.startIndex);
@@ -318,6 +335,7 @@ function assertCursorState(cursor, params) {
   const node = cursor.currentNode
   assert.equal(node.type, params.nodeType);
   assert.equal(node.isNamed, params.nodeIsNamed);
+  assert.equal(node.isMissing(), params.nodeIsMissing);
   assert.deepEqual(node.startPosition, params.startPosition);
   assert.deepEqual(node.endPosition, params.endPosition);
   assert.deepEqual(node.startIndex, params.startIndex);

--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -100,6 +100,7 @@ declare module "tree-sitter" {
       nodeType: string;
       nodeText: string;
       nodeIsNamed: boolean;
+      nodeIsMissing: boolean;
       startPosition: Point;
       endPosition: Point;
       startIndex: number;


### PR DESCRIPTION
During my research into tree-sitter CST traversal, I found out that Node.js tree-sitter binding doesn't contain cached getter `nodeIsMissing`. Because of that, when using TreeCursor, the only way to determine if the SyntaxNode is missing is to call the `cursor.currentNode.isMissing()` method. By doing this, traversal performance goes out the window. [web-binding](https://github.com/tree-sitter/tree-sitter/blob/de53b82e2c48d6221af9881e50cc57d961de3365/lib/binding_web/binding.c#L258) for tree-sitter exposes `nodeIsMissing` cached field, but Node.js binding doesn't. This PR remedies the situation.

**Before**:

```js
cursor = tree.walk();
cursor.currentNode.isMissing();
```

**After**:

```js
cursor = tree.walk();
cursor.nodeIsMissing;
```

Refs https://github.com/tree-sitter/tree-sitter/issues/1469

Signed-off-by: Vladimir Gorej <vladimir.gorej@gmail.com>