### PR TITLE
feat: add childNodeForFieldName

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,6 +246,11 @@ class SyntaxNode {
     cursor.tree = this.tree;
     return cursor;
   }
+
+  childNodeForFieldName(fieldName) {
+    marshalNode(this);
+    return unmarshalNode(NodeMethods.childNodeForFieldName(this.tree, fieldName), this.tree);
+  }
 }
 
 /*

--- a/test/node_test.js
+++ b/test/node_test.js
@@ -415,4 +415,14 @@ describe("Node", () => {
       })
     )
   })
+
+  describe(".childNodeForFieldName", () => {
+    it(`finds a child node by name`, async () => {
+      const tree = parser.parse(`1 + 2`);
+
+      const node = tree.rootNode?.firstChild?.firstChild;
+      assert.equal(node?.childNodeForFieldName("left").text, '1');
+      assert.equal(node?.childNodeForFieldName("right").text, '2');
+    });
+  })
 });


### PR DESCRIPTION
This adds a wrapper for the `ts_node_child_by_field_name` function directly (c.f. #99) . I realized, as I was working on this, that it is already possible to use the generated property getters, which go via field IDs, but in any case, this might be useful as it brings the API closer to parity with `web-tree-sitter` (#68)

My C++ is extremely rusty (no pun intended) so I'm happy to take any pointers on style etc. there, but I mostly followed the examples in the other functions.

I added a minimal test case, but I could add additional test cases if we agree this is useful.

Thanks!