### PR TITLE
Fix: Query fails to match optional node when using #eq? predicate

### DIFF
--- a/index.js
+++ b/index.js
@@ -438,6 +438,7 @@ Query.prototype._init = function() {
                 if (c.name === captureName1) node1 = c.node;
                 if (c.name === captureName2) node2 = c.node;
               }
+              if (node1 === undefined || node2 === undefined) return true;
               return (node1.text === node2.text) === isPositive;
             });
           } else {
@@ -449,7 +450,7 @@ Query.prototype._init = function() {
                   return (c.node.text === stringValue) === isPositive;
                 };
               }
-              return false;
+              return true;
             });
           }
           break;
@@ -470,7 +471,7 @@ Query.prototype._init = function() {
             for (const c of captures) {
               if (c.name === captureName) return regex.test(c.node.text);
             }
-            return false;
+            return true;
           });
           break;
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "mocha": "^8.3.1",
     "prebuild": "^10.0.1",
     "superstring": "^2.4.2",
-    "tree-sitter-javascript": "git://github.com/tree-sitter/tree-sitter-javascript.git#master"
+    "tree-sitter-javascript": "https://github.com/tree-sitter/tree-sitter-javascript.git#master"
   },
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -55,6 +55,25 @@ describe("Query", () => {
         { pattern: 0, captures: [{ name: "element", text: "g" }] },
       ]);
     });
+
+    it("finds optional nodes even when using #eq? predicate", () => {
+      const tree = parser.parse(`
+        { one: true };
+        { one: true, two: true };
+      `);
+      const query = new Query(JavaScript, `
+        (
+          (object (pair key: (property_identifier) @a) (pair key: (property_identifier) @b)?)
+          (#eq? @a one)
+          (#eq? @b two)
+        )
+      `);
+      const matches = query.matches(tree.rootNode);
+      assert.deepEqual(formatMatches(tree, matches), [
+        { pattern: 0, captures: [{ name: 'a', text: 'one' }] },
+        { pattern: 0, captures: [{ name: 'a', text: 'one' }, { name: 'b', text: 'two' }] },
+      ]);
+    });
   });
 
   describe(".captures", () => {


### PR DESCRIPTION
Fixes: #107

This is just the same fix as https://github.com/tree-sitter/tree-sitter/commit/79b2bf1c30c65e8450f3712fcaffa39c6c3301b1

Also contains a drive-by fix to use https when cloning the tree-sitter-javascript repo as a dev dependency.