### PR TITLE
Insert sanity check in marshalNode

### DIFF
--- a/index.js
+++ b/index.js
@@ -677,7 +677,7 @@ function unmarshalNodes(nodes, tree) {
 
 function marshalNode(node) {
   if (!(node.tree instanceof Tree)){
-    throw new Error("This node does not belong to a valid tree")
+    throw new TypeError("SyntaxNode must belong to a Tree")
   }
   const {nodeTransferArray} = binding;
   for (let i = 0; i < NODE_FIELD_COUNT; i++) {

--- a/index.js
+++ b/index.js
@@ -676,6 +676,9 @@ function unmarshalNodes(nodes, tree) {
 }
 
 function marshalNode(node) {
+  if (!(node.tree instanceof Tree)){
+    throw new Error("This node does not belong to a valid tree")
+  }
   const {nodeTransferArray} = binding;
   for (let i = 0; i < NODE_FIELD_COUNT; i++) {
     nodeTransferArray[i] = node[i];


### PR DESCRIPTION
This prevents the VSCode debugger from crashing in the native bindings when trying to autocomplete properties on a `SyntaxNode` or when examining the prototype object.