### PR TITLE
Remove deprecated v8::Object::CreationContext()

### DIFF
--- a/src/logger.cc
+++ b/src/logger.cc
@@ -41,14 +41,14 @@ void Logger::Log(void *payload, TSLogType type, const char *message_str) {
 
   Local<Value> argv[3] = { name, params, type_name };
   TryCatch try_catch(Isolate::GetCurrent());
-  Nan::Call(fn, fn->CreationContext()->Global(), 3, argv);
+  Nan::Call(fn, fn->GetCreationContextChecked()->Global(), 3, argv);
   if (try_catch.HasCaught()) {
     Local<Value> log_argv[2] = {
       Nan::New("Error in debug callback:").ToLocalChecked(),
       try_catch.Exception()
     };
 
-    Local<Object> console = Local<Object>::Cast(Nan::Get(fn->CreationContext()->Global(), Nan::New("console").ToLocalChecked()).ToLocalChecked());
+    Local<Object> console = Local<Object>::Cast(Nan::Get(fn->GetCreationContextChecked()->Global(), Nan::New("console").ToLocalChecked()).ToLocalChecked());
     Local<Function> error_fn = Local<Function>::Cast(Nan::Get(console, Nan::New("error").ToLocalChecked()).ToLocalChecked());
     Nan::Call(error_fn, console, 2, log_argv);
   }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -60,7 +60,7 @@ class CallbackInput {
       uint32_t utf16_unit = byte / 2;
       Local<Value> argv[2] = { Nan::New<Number>(utf16_unit), PointToJS(position) };
       TryCatch try_catch(Isolate::GetCurrent());
-      auto maybe_result_value = Nan::Call(callback, callback->CreationContext()->Global(), 2, argv);
+      auto maybe_result_value = Nan::Call(callback, callback->GetCreationContextChecked()->Global(), 2, argv);
       if (try_catch.HasCaught()) return nullptr;
 
       Local<Value> result_value;
@@ -364,7 +364,7 @@ void Parser::ParseTextBuffer(const Nan::FunctionCallbackInfo<Value> &info) {
       delete input;
       Local<Value> argv[] = {Tree::NewInstance(result)};
       auto callback = info[0].As<Function>();
-      Nan::Call(callback, callback->CreationContext()->Global(), 1, argv);
+      Nan::Call(callback, callback->GetCreationContextChecked()->Global(), 1, argv);
       return;
     }
   }


### PR DESCRIPTION
This method was deprecated for a while, and is completely removed in Electron 20, causing compile errors. GetCreationContextChecked() seems to be a drop-in replacement. See https://groups.google.com/a/chromium.org/g/blink-reviews-bindings/c/VxbRacYaigA for precedent.