### PR TITLE
make module context aware

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -22,6 +22,6 @@ void InitAll(Local<Object> exports) {
   TreeCursor::Init(exports);
 }
 
-NODE_MODULE(tree_sitter_runtime_binding, InitAll)
+NAN_MODULE_WORKER_ENABLED(tree_sitter_runtime_binding, InitAll)
 
 }  // namespace node_tree_sitter


### PR DESCRIPTION
Hey, I'm trying to use your awesome bindings in electron, but unfortunately I get complaints that it should not be non-context aware. After digging through stack overflow I found this: https://github.com/electron/electron/issues/18397 where they explain you can make a node library context aware simply by applying the change in this pull request. I tried to build the project myself, but that proved to be quite a lot of work, probably also because I am on an m1 mac. I haven't succeeded yet. Could you have a look at this to see if it works? I could of course not test it given that I cannot yet build the project, even without any changes.