### PR TITLE
fix: make the native addon context-aware

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -24,15 +24,13 @@
         ['OS == "mac"', {
           'xcode_settings': {
             'MACOSX_DEPLOYMENT_TARGET': '10.9',
+            'CLANG_CXX_LANGUAGE_STANDARD': 'c++17',
           },
         }]
       ],
       "cflags": [
         "-std=c++17",
       ],
-      'xcode_settings': {
-        'CLANG_CXX_LANGUAGE_STANDARD': 'c++17',
-      },
     },
     {
       "target_name": "tree_sitter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Incremental parsers for node",
   "author": "Max Brunsfeld",
   "license": "MIT",

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -22,6 +22,6 @@ void InitAll(Local<Object> exports) {
   TreeCursor::Init(exports);
 }
 
-NODE_MODULE(tree_sitter_runtime_binding, InitAll)
+NAN_MODULE_WORKER_ENABLED(tree_sitter_runtime_binding, InitAll)
 
 }  // namespace node_tree_sitter


### PR DESCRIPTION
Since Electron 14, all native add-ons must be context-aware. Therefore, in order to make `node-tree-sitter` run with Electron >= 14, it has to be context-aware. Ref: https://github.com/electron/electron/issues/18397

In this PR, `NAN_MODULE_WORKER_ENABLED` is used to make the native addon context-aware. It will allow context as the third param but will ignore context. Although context param will be accepted, this change doesn't mean that the addon will be safe to be initialised multiple times and can be run safely on worker threads. Perhaps, someone with a better understanding of the library helps to implement AddEnvironmentCleanupHook to clean up global static resources. Ref: https://nodejs.org/api/addons.html#context-aware-addons

Another minor change: `xcode_settings` settings are consolidated into a single place.