### PR TITLE
Make code compilable on Node 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "mocha": "^8.3.1",
     "prebuild": "^10.0.1",
     "superstring": "^2.4.2",
-    "tree-sitter-javascript": "https://github.com/tree-sitter/tree-sitter-javascript.git#master"
+    "tree-sitter-javascript": "https://github.com/tree-sitter/tree-sitter-javascript.git#936d976a782e75395d9b1c8c7c7bf4ba6fe0d86b"
   },
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -34,7 +34,7 @@ void InitConversions(Local<Object> exports) {
     v8::Local<v8::Object> bufferView;
     bufferView = node::Buffer::New(Isolate::GetCurrent(), point_transfer_buffer, 0, 2 * sizeof(uint32_t)).ToLocalChecked();
     auto js_point_transfer_buffer = node::Buffer::Data(bufferView);
-  #elif V8_MAJOR_VERSION >= 8
+  #elif (V8_MAJOR_VERSION > 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERION > 3))
     auto backing_store = ArrayBuffer::NewBackingStore(point_transfer_buffer, 2 * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
     auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
   #else

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -41,14 +41,24 @@ void Logger::Log(void *payload, TSLogType type, const char *message_str) {
 
   Local<Value> argv[3] = { name, params, type_name };
   TryCatch try_catch(Isolate::GetCurrent());
-  Nan::Call(fn, fn->CreationContext()->Global(), 3, argv);
+
+  #if (V8_MAJOR_VERSION > 9 || (V8_MAJOR_VERSION == 9 && V8_MINOR_VERION > 4))
+    Nan::Call(fn, fn->GetCreationContext().ToLocalChecked()->Global(), 3, argv);
+  #else
+    Nan::Call(fn, fn->CreationContext()->Global(), 3, argv);
+  #endif
   if (try_catch.HasCaught()) {
     Local<Value> log_argv[2] = {
       Nan::New("Error in debug callback:").ToLocalChecked(),
       try_catch.Exception()
     };
 
-    Local<Object> console = Local<Object>::Cast(Nan::Get(fn->CreationContext()->Global(), Nan::New("console").ToLocalChecked()).ToLocalChecked());
+
+    #if (V8_MAJOR_VERSION > 9 || (V8_MAJOR_VERSION == 9 && V8_MINOR_VERION > 4))
+      Local<Object> console = Local<Object>::Cast(Nan::Get(fn->GetCreationContext().ToLocalChecked()->Global(), Nan::New("console").ToLocalChecked()).ToLocalChecked());
+    #else
+      Local<Object> console = Local<Object>::Cast(Nan::Get(fn->CreationContext()->Global(), Nan::New("console").ToLocalChecked()).ToLocalChecked());
+    #endif
     Local<Function> error_fn = Local<Function>::Cast(Nan::Get(console, Nan::New("error").ToLocalChecked()).ToLocalChecked());
     Nan::Call(error_fn, console, 2, log_argv);
   }

--- a/src/node.cc
+++ b/src/node.cc
@@ -35,7 +35,7 @@ static inline void setup_transfer_buffer(uint32_t node_count) {
       v8::Local<v8::Object> bufferView;
       bufferView = node::Buffer::New(Isolate::GetCurrent(), transfer_buffer, 0, transfer_buffer_length * sizeof(uint32_t)).ToLocalChecked();
       auto js_point_transfer_buffer = node::Buffer::Data(bufferView);
-    #elif V8_MAJOR_VERSION >= 8
+    #elif (V8_MAJOR_VERSION > 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERION > 3))
       auto backing_store = ArrayBuffer::NewBackingStore(transfer_buffer, transfer_buffer_length * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
       auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
     #else

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -60,7 +60,11 @@ class CallbackInput {
       uint32_t utf16_unit = byte / 2;
       Local<Value> argv[2] = { Nan::New<Number>(utf16_unit), PointToJS(position) };
       TryCatch try_catch(Isolate::GetCurrent());
-      auto maybe_result_value = Nan::Call(callback, callback->CreationContext()->Global(), 2, argv);
+      #if (V8_MAJOR_VERSION > 9 || (V8_MAJOR_VERSION == 9 && V8_MINOR_VERION > 4))
+        auto maybe_result_value = Nan::Call(callback, callback->GetCreationContext().ToLocalChecked()->Global(), 2, argv);
+      #else
+        auto maybe_result_value = Nan::Call(callback, callback->CreationContext()->Global(), 2, argv);
+      #endif
       if (try_catch.HasCaught()) return nullptr;
 
       Local<Value> result_value;
@@ -364,7 +368,11 @@ void Parser::ParseTextBuffer(const Nan::FunctionCallbackInfo<Value> &info) {
       delete input;
       Local<Value> argv[] = {Tree::NewInstance(result)};
       auto callback = info[0].As<Function>();
-      Nan::Call(callback, callback->CreationContext()->Global(), 1, argv);
+      #if (V8_MAJOR_VERSION > 9 || (V8_MAJOR_VERSION == 9 && V8_MINOR_VERION > 4))
+        Nan::Call(callback, callback->GetCreationContext().ToLocalChecked()->Global(), 1, argv);
+      #else
+        Nan::Call(callback, callback->CreationContext()->Global(), 1, argv);
+      #endif
       return;
     }
   }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -60,11 +60,7 @@ class CallbackInput {
       uint32_t utf16_unit = byte / 2;
       Local<Value> argv[2] = { Nan::New<Number>(utf16_unit), PointToJS(position) };
       TryCatch try_catch(Isolate::GetCurrent());
-      #if (V8_MAJOR_VERSION > 9 || (V8_MAJOR_VERSION == 9 && V8_MINOR_VERION > 4))
-        auto maybe_result_value = Nan::Call(callback, callback->GetCreationContext().ToLocalChecked()->Global(), 2, argv);
-      #else
-        auto maybe_result_value = Nan::Call(callback, callback->CreationContext()->Global(), 2, argv);
-      #endif
+      auto maybe_result_value = Nan::Call(callback, GetGlobal(callback), 2, argv);
       if (try_catch.HasCaught()) return nullptr;
 
       Local<Value> result_value;
@@ -368,11 +364,7 @@ void Parser::ParseTextBuffer(const Nan::FunctionCallbackInfo<Value> &info) {
       delete input;
       Local<Value> argv[] = {Tree::NewInstance(result)};
       auto callback = info[0].As<Function>();
-      #if (V8_MAJOR_VERSION > 9 || (V8_MAJOR_VERSION == 9 && V8_MINOR_VERION > 4))
-        Nan::Call(callback, callback->GetCreationContext().ToLocalChecked()->Global(), 1, argv);
-      #else
-        Nan::Call(callback, callback->CreationContext()->Global(), 1, argv);
-      #endif
+      Nan::Call(callback, GetGlobal(callback), 1, argv);
       return;
     }
   }

--- a/src/util.cc
+++ b/src/util.cc
@@ -11,4 +11,12 @@ bool instance_of(v8::Local<v8::Value> value, v8::Local<v8::Object> object) {
   return maybe_bool.FromJust();
 }
 
+v8::Local<v8::Object> GetGlobal(v8::Local<v8::Function>& callback) {
+  #if (V8_MAJOR_VERSION > 9 || (V8_MAJOR_VERSION == 9 && V8_MINOR_VERION > 4))
+    return callback->GetCreationContext().ToLocalChecked()->Global();
+  #else
+    return callback->CreationContext()->Global();
+  #endif
+}
+
 }  // namespace node_tree_sitter

--- a/src/util.h
+++ b/src/util.h
@@ -20,6 +20,8 @@ struct FunctionPair {
 
 bool instance_of(v8::Local<v8::Value> value, v8::Local<v8::Object> object);
 
+v8::Local<v8::Object> GetGlobal(v8::Local<v8::Function>& callback);
+
 }  // namespace node_tree_sitter
 
 #endif  // NODE_TREE_SITTER_UTIL_H_


### PR DESCRIPTION
`GetCreationContext` was introduced in https://github.com/v8/v8/commit/b38bf5b0b1f149f7af3fd90a2ce12344e7191d03 released as V8 version 9.1 (probably, I'm just looking at the `git tag`s the commit belongs to and the state of https://github.com/v8/v8/blob/main/include/v8-version.h when the commit is made). Later they added a `GetCreationContextChecked` in https://github.com/v8/v8/commit/91475f958a044bf756314e43a4601b4f09abfe4b 9.7.64 which does the same thing as `CreationContext`. `CreationContext` was removed in commit [46224e7](https://github.com/v8/v8/commit/46224e75f3a42fb7ab1291c63d642e69dcdb4ac9#diff-33c4d36aeca8daf49e5dc90e3753462292180290ffd6b0d5a88ed55ab58a7817L5101) released as 10.3 (the commit says 10.2 but I think it's lying). So as per [this table](https://nodejs.org/en/download/releases):

Version | LTS | Date | V8 | npm | NODE_MODULE_VERSION
-- | -- | -- | -- | -- | --
Node.js 20.3.0 |   | 2023-06-08 | 11.3.244.8 | 9.6.7 | 115
Node.js 19.9.0 |   | 2023-04-10 | 10.8.168.25 | 9.6.3 | 111
Node.js 18.16.0 | Hydrogen | 2023-04-12 | 10.2.154.26 | 9.5.1 | 108
Node.js 17.9.1 |   | 2022-06-01 | 9.6.180.15 | 8.11.0 | 102
Node.js 16.20.0 | Gallium | 2023-03-28 | 9.4.146.26 | 8.19.4 | 93
Node.js 15.14.0 |   | 2021-04-06 | 8.6.395.17 | 7.7.6 | 88
Node.js 14.21.3 | Fermium | 2023-02-16 | 8.4.371.23 | 6.14.18 | 83
Node.js 13.14.0 |   | 2020-04-29 | 7.9.317.25 | 6.14.4 | 79

node-tree-sitter is trying to use a function that doesn't exist in Node 19+. The oldest supported Electron version, [Electron 22](https://releases.electronjs.org/release/v22.3.12) uses V8 10.8.168.25 so this must be a problem there too, but I guess no one is using node-tree-sitter with Electron?

Note that after this commit node-tree-sitter still won't compile on Node 19+ due to the [superstring](https://github.com/atom/superstring) dependency not supporting Node 19 for the exact same reason, but merging this shouldn't break anything.

This PR contains only the most relevant changes from #127