### PR TITLE
Fix vscode/electron crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -611,7 +611,8 @@ function getTextFromTextBuffer ({startPosition, endPosition}) {
   return this.input.getTextInRange({start: startPosition, end: endPosition});
 }
 
-const {pointTransferArray} = binding;
+let {pointTransferArray} = binding;
+pointTransferArray = new Uint32Array(pointTransferArray.buffer);
 
 const NODE_FIELD_COUNT = 6;
 const ERROR_TYPE_ID = 0xFFFF
@@ -635,7 +636,9 @@ function unmarshalNode(value, tree, offset = 0, cache = null) {
     ? SyntaxNode
     : tree.language.nodeSubclasses[nodeTypeId];
 
-  const {nodeTransferArray} = binding;
+  let {nodeTransferArray} = binding;
+  nodeTransferArray = new Uint32Array(nodeTransferArray.buffer);
+
   const id = getID(nodeTransferArray, offset)
   if (id === 0n) {
     return null
@@ -676,7 +679,8 @@ function unmarshalNodes(nodes, tree) {
 }
 
 function marshalNode(node) {
-  const {nodeTransferArray} = binding;
+  let {nodeTransferArray} = binding;
+  nodeTransferArray = new Uint32Array(nodeTransferArray.buffer);
   for (let i = 0; i < NODE_FIELD_COUNT; i++) {
     nodeTransferArray[i] = node[i];
   }

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -29,19 +29,21 @@ void InitConversions(Local<Object> exports) {
 
   point_transfer_buffer = static_cast<uint32_t *>(malloc(2 * sizeof(uint32_t)));
 
-  #if _MSC_VER && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
+  // #if _MSC_VER && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
     // this is a terrible thing we have to do because of https://github.com/electron/electron/issues/29893
     v8::Local<v8::Object> bufferView;
-    bufferView = node::Buffer::New(Isolate::GetCurrent(), point_transfer_buffer, 0, 2 * sizeof(uint32_t)).ToLocalChecked();
-    auto js_point_transfer_buffer = node::Buffer::Data(bufferView);
-  #elif (V8_MAJOR_VERSION > 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERION > 3))
-    auto backing_store = ArrayBuffer::NewBackingStore(point_transfer_buffer, 2 * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
-    auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
-  #else
-    auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), point_transfer_buffer, 2 * sizeof(uint32_t));
-  #endif
+    bufferView = node::Buffer::New(Isolate::GetCurrent(), (char *) point_transfer_buffer, (size_t) (2 * sizeof(uint32_t))).ToLocalChecked();
+    // bufferView = node::Buffer::New(Isolate::GetCurrent(), point_transfer_buffer, 0, 2 * sizeof(uint32_t)).ToLocalChecked();
+    // auto js_point_transfer_buffer = node::Buffer::Data(bufferView);
+  // #elif (V8_MAJOR_VERSION > 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERION > 3))
+    // auto backing_store = ArrayBuffer::NewBackingStore(point_transfer_buffer, 2 * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
+    // auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
+  // #else
+  //   auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), point_transfer_buffer, 2 * sizeof(uint32_t));
+  // #endif
 
-  Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), Uint32Array::New(js_point_transfer_buffer, 0, 2));
+  // Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), Uint32Array::New(js_point_transfer_buffer, 0, 2));
+  Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), bufferView);
 }
 
 void TransferPoint(const TSPoint &point) {

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -37,10 +37,10 @@ void InitConversions(Local<Object> exports) {
   #elif (V8_MAJOR_VERSION > 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERION > 3))
     auto backing_store = ArrayBuffer::NewBackingStore(point_transfer_buffer, 2 * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
     auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
-    Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), bufferView);
+    Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), Uint32Array::New(js_point_transfer_buffer, 0, 2));
   #else
     auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), point_transfer_buffer, 2 * sizeof(uint32_t));
-    Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), bufferView);
+    Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), Uint32Array::New(js_point_transfer_buffer, 0, 2));
   #endif
 }
 

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -32,7 +32,7 @@ void InitConversions(Local<Object> exports) {
   #if /*_MSC_VER && NODE_RUNTIME_ELECTRON && */ NODE_MODULE_VERSION >= 89
     // this is a terrible thing we have to do because of https://github.com/electron/electron/issues/29893
     v8::Local<v8::Object> bufferView;
-    bufferView = node::Buffer::New(Isolate::GetCurrent(), (char *) point_transfer_buffer, (size_t) (2 * sizeof(uint32_t))).ToLocalChecked();
+    bufferView = node::Buffer::New(Isolate::GetCurrent(), (char *) point_transfer_buffer, (2 * sizeof(uint32_t))).ToLocalChecked();
     Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), bufferView);
   #elif (V8_MAJOR_VERSION > 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERION > 3))
     auto backing_store = ArrayBuffer::NewBackingStore(point_transfer_buffer, 2 * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -29,21 +29,19 @@ void InitConversions(Local<Object> exports) {
 
   point_transfer_buffer = static_cast<uint32_t *>(malloc(2 * sizeof(uint32_t)));
 
-  // #if _MSC_VER && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
+  #if /*_MSC_VER && NODE_RUNTIME_ELECTRON && */ NODE_MODULE_VERSION >= 89
     // this is a terrible thing we have to do because of https://github.com/electron/electron/issues/29893
     v8::Local<v8::Object> bufferView;
     bufferView = node::Buffer::New(Isolate::GetCurrent(), (char *) point_transfer_buffer, (size_t) (2 * sizeof(uint32_t))).ToLocalChecked();
-    // bufferView = node::Buffer::New(Isolate::GetCurrent(), point_transfer_buffer, 0, 2 * sizeof(uint32_t)).ToLocalChecked();
-    // auto js_point_transfer_buffer = node::Buffer::Data(bufferView);
-  // #elif (V8_MAJOR_VERSION > 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERION > 3))
-    // auto backing_store = ArrayBuffer::NewBackingStore(point_transfer_buffer, 2 * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
-    // auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
-  // #else
-  //   auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), point_transfer_buffer, 2 * sizeof(uint32_t));
-  // #endif
-
-  // Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), Uint32Array::New(js_point_transfer_buffer, 0, 2));
-  Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), bufferView);
+    Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), bufferView);
+  #elif (V8_MAJOR_VERSION > 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERION > 3))
+    auto backing_store = ArrayBuffer::NewBackingStore(point_transfer_buffer, 2 * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
+    auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
+    Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), bufferView);
+  #else
+    auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), point_transfer_buffer, 2 * sizeof(uint32_t));
+    Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), bufferView);
+  #endif
 }
 
 void TransferPoint(const TSPoint &point) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -30,22 +30,24 @@ static inline void setup_transfer_buffer(uint32_t node_count) {
     transfer_buffer_length = new_length;
     transfer_buffer = static_cast<uint32_t *>(malloc(transfer_buffer_length * sizeof(uint32_t)));
 
-    #if _MSC_VER && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
+    // #if _MSC_VER && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
       // this is a terrible thing we have to do because of https://github.com/electron/electron/issues/29893
       v8::Local<v8::Object> bufferView;
-      bufferView = node::Buffer::New(Isolate::GetCurrent(), transfer_buffer, 0, transfer_buffer_length * sizeof(uint32_t)).ToLocalChecked();
+      // bufferView = node::Buffer::New(Isolate::GetCurrent(), transfer_buffer, 0, transfer_buffer_length * sizeof(uint32_t)).ToLocalChecked();
+      bufferView = node::Buffer::New(Isolate::GetCurrent(), (char *) transfer_buffer, (size_t) (transfer_buffer_length * sizeof(uint32_t))).ToLocalChecked();
       auto js_point_transfer_buffer = node::Buffer::Data(bufferView);
-    #elif (V8_MAJOR_VERSION > 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERION > 3))
-      auto backing_store = ArrayBuffer::NewBackingStore(transfer_buffer, transfer_buffer_length * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
-      auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
-    #else
-      auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer, transfer_buffer_length * sizeof(uint32_t));
-    #endif
+    // #elif (V8_MAJOR_VERSION > 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERION > 3))
+    //   auto backing_store = ArrayBuffer::NewBackingStore(transfer_buffer, transfer_buffer_length * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
+    //   auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
+    // #else
+    //   auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer, transfer_buffer_length * sizeof(uint32_t));
+    // #endif
 
     Nan::Set(
       Nan::New(module_exports),
       Nan::New("nodeTransferArray").ToLocalChecked(),
-      Uint32Array::New(js_transfer_buffer, 0, transfer_buffer_length)
+      // Uint32Array::New(js_transfer_buffer, 0, transfer_buffer_length)
+      bufferView
     );
   }
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -33,7 +33,7 @@ static inline void setup_transfer_buffer(uint32_t node_count) {
     #if /*_MSC_VER && NODE_RUNTIME_ELECTRON && */ NODE_MODULE_VERSION >= 89
       // this is a terrible thing we have to do because of https://github.com/electron/electron/issues/29893
       v8::Local<v8::Object> bufferView;
-      bufferView = node::Buffer::New(Isolate::GetCurrent(), (char *) transfer_buffer, (size_t) (transfer_buffer_length * sizeof(uint32_t))).ToLocalChecked();
+      bufferView = node::Buffer::New(Isolate::GetCurrent(), (char *) transfer_buffer, transfer_buffer_length * sizeof(uint32_t)).ToLocalChecked();
       Nan::Set(Nan::New(module_exports), Nan::New("nodeTransferArray").ToLocalChecked(), bufferView);
     #elif (V8_MAJOR_VERSION > 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERION > 3))
       auto backing_store = ArrayBuffer::NewBackingStore(transfer_buffer, transfer_buffer_length * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
@@ -91,17 +91,22 @@ Local<Value> GetMarshalNodes(const Nan::FunctionCallbackInfo<Value> &info,
 
 Local<Value> GetMarshalNode(const Nan::FunctionCallbackInfo<Value> &info, const Tree *tree, TSNode node) {
   const auto &cache_entry = tree->cached_nodes_.find(node.id);
+  auto cond = cache_entry == tree->cached_nodes_.end();
+  auto end = tree->cached_nodes_.end();
   if (cache_entry == tree->cached_nodes_.end()) {
     setup_transfer_buffer(1);
     uint32_t *p = transfer_buffer;
+    auto sizeOfId = sizeof(node.id);
     MarshalNodeId(node.id, p);
     p += 2;
     *(p++) = node.context[0];
     *(p++) = node.context[1];
     *(p++) = node.context[2];
     *(p++) = node.context[3];
+    auto cond2 = !!node.id;
     if (node.id) {
-      return Nan::New(ts_node_symbol(node));
+      auto res = ts_node_symbol(node);
+      return Nan::New(res);
     }
   } else {
     return Nan::New(cache_entry->second->node);

--- a/src/node.cc
+++ b/src/node.cc
@@ -30,25 +30,20 @@ static inline void setup_transfer_buffer(uint32_t node_count) {
     transfer_buffer_length = new_length;
     transfer_buffer = static_cast<uint32_t *>(malloc(transfer_buffer_length * sizeof(uint32_t)));
 
-    // #if _MSC_VER && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
+    #if /*_MSC_VER && NODE_RUNTIME_ELECTRON && */ NODE_MODULE_VERSION >= 89
       // this is a terrible thing we have to do because of https://github.com/electron/electron/issues/29893
       v8::Local<v8::Object> bufferView;
-      // bufferView = node::Buffer::New(Isolate::GetCurrent(), transfer_buffer, 0, transfer_buffer_length * sizeof(uint32_t)).ToLocalChecked();
       bufferView = node::Buffer::New(Isolate::GetCurrent(), (char *) transfer_buffer, (size_t) (transfer_buffer_length * sizeof(uint32_t))).ToLocalChecked();
-      auto js_point_transfer_buffer = node::Buffer::Data(bufferView);
-    // #elif (V8_MAJOR_VERSION > 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERION > 3))
-    //   auto backing_store = ArrayBuffer::NewBackingStore(transfer_buffer, transfer_buffer_length * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
-    //   auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
-    // #else
-    //   auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer, transfer_buffer_length * sizeof(uint32_t));
-    // #endif
+      Nan::Set(Nan::New(module_exports), Nan::New("nodeTransferArray").ToLocalChecked(), bufferView);
+    #elif (V8_MAJOR_VERSION > 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERION > 3))
+      auto backing_store = ArrayBuffer::NewBackingStore(transfer_buffer, transfer_buffer_length * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
+      auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
+      Nan::Set(Nan::New(module_exports), Nan::New("nodeTransferArray").ToLocalChecked(), Uint32Array::New(js_transfer_buffer, 0, transfer_buffer_length));
+    #else
+      auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer, transfer_buffer_length * sizeof(uint32_t));
+      Nan::Set(Nan::New(module_exports), Nan::New("nodeTransferArray").ToLocalChecked(), Uint32Array::New(js_transfer_buffer, 0, transfer_buffer_length));
+    #endif
 
-    Nan::Set(
-      Nan::New(module_exports),
-      Nan::New("nodeTransferArray").ToLocalChecked(),
-      // Uint32Array::New(js_transfer_buffer, 0, transfer_buffer_length)
-      bufferView
-    );
   }
 }
 


### PR DESCRIPTION
This PR makes `node-tree-sitter` run in Electron v22 (NODE_MODULE_VERSION 110).

The current patch for this is incomplete (#134). This PR finishes it (hopefully).

I've marked this as a draft, since I had trouble with this #if:

```cpp
#if /*_MSC_VER && NODE_RUNTIME_ELECTRON && */ NODE_MODULE_VERSION >= 89
```

Both `_MSC_VER` and `NODE_RUNTIME_ELECTRON` were not set, and I couldn't figure out how to set them.

Otherwise this worked for me when running from this VSCode on an M1 mac:

```
Version: 1.79.2
Commit: 695af097c7bd098fbf017ce3ac85e09bbc5dda06
Date: 2023-06-14T08:58:33.551Z (4 days ago)
Electron: 22.5.7
Chromium: 108.0.5359.215
Node.js: 16.17.1
V8: 10.8.168.25-electron.0
OS: Darwin arm64 22.5.0
```

Testing repo: https://github.com/selfint/vscode-tree-sitter