### PR TITLE
Keep API in-line with upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ env:
   ELECTRON_PREBUILD_CMD: npx prebuild -r electron -t 3.0.0 -t 4.0.0 -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.0 -t 18.0.0 -t 19.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0 -t 23.0.0 -t 24.0.0 -t 25.0.0 --strip -u ${{ secrets.GH_TOKEN }}
 
 jobs:
-
   test:
     strategy:
       matrix:

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,6 +8,7 @@
         "src/conversions.cc",
         "src/language.cc",
         "src/logger.cc",
+        "src/lookaheaditerator.cc",
         "src/node.cc",
         "src/parser.cc",
         "src/query.cc",

--- a/package.json
+++ b/package.json
@@ -19,12 +19,21 @@
     "prebuild-install": "^7.1.1"
   },
   "devDependencies": {
-    "@types/node": "^20.5.9",
+    "@types/node": "^20.6.0",
     "chai": "^4.3.8",
-    "mocha": "^8.4.0",
+    "mocha": "^10.2.0",
     "node-gyp": "^9.4.0",
     "prebuild": "^12.0.0",
-    "tree-sitter-javascript": "https://github.com/tree-sitter/tree-sitter-javascript.git#master"
+    "tmp": "^0.2.1",
+    "tree-sitter-c": "https://github.com/tree-sitter/tree-sitter-c.git#master",
+    "tree-sitter-embedded-template": "https://github.com/tree-sitter/tree-sitter-embedded-template.git#master",
+    "tree-sitter-html": "https://github.com/tree-sitter/tree-sitter-html.git#master",
+    "tree-sitter-java": "https://github.com/tree-sitter/tree-sitter-java.git#master",
+    "tree-sitter-javascript": "https://github.com/tree-sitter/tree-sitter-javascript.git#master",
+    "tree-sitter-json": "https://github.com/tree-sitter/tree-sitter-json.git#master",
+    "tree-sitter-python": "https://github.com/tree-sitter/tree-sitter-python.git#master",
+    "tree-sitter-ruby": "https://github.com/tree-sitter/tree-sitter-ruby.git#master",
+    "tree-sitter-rust": "https://github.com/tree-sitter/tree-sitter-rust.git#master"
   },
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1,5 +1,6 @@
 #include "./language.h"
 #include "./conversions.h"
+#include "./lookaheaditerator.h"
 #include "./node.h"
 #include "./parser.h"
 #include "./query.h"
@@ -17,6 +18,7 @@ void InitAll(Local<Object> exports, Local<Value> m_, void* v_) {
   InitConversions(exports);
   node_methods::Init(exports);
   language_methods::Init(exports);
+  LookaheadIterator::Init(exports);
   Parser::Init(exports);
   Query::Init(exports);
   Tree::Init(exports);

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1,12 +1,13 @@
-#include <node.h>
-#include <v8.h>
 #include "./language.h"
+#include "./conversions.h"
 #include "./node.h"
 #include "./parser.h"
 #include "./query.h"
 #include "./tree.h"
 #include "./tree_cursor.h"
-#include "./conversions.h"
+
+#include <node.h>
+#include <v8.h>
 
 namespace node_tree_sitter {
 

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -77,9 +77,9 @@ Nan::Maybe<TSRange> RangeFromJS(const Local<Value> &arg) {
       Nan::ThrowTypeError("Range must be a {startPosition, endPosition, startIndex, endIndex} object"); \
       return Nan::Nothing<TSRange>(); \
     } \
-    auto field = Convert(value.ToLocalChecked()); \
-    if (field.IsJust()) { \
-      result.field = field.FromJust(); \
+    auto (field) = Convert(value.ToLocalChecked()); \
+    if ((field).IsJust()) { \
+      result.field = (field).FromJust(); \
     } else { \
       return Nan::Nothing<TSRange>(); \
     } \

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -1,9 +1,10 @@
 #include "./node.h"
-#include <nan.h>
-#include <tree_sitter/api.h>
-#include <v8.h>
 #include "./conversions.h"
+#include "tree_sitter/api.h"
+
 #include <cmath>
+#include <nan.h>
+#include <v8.h>
 
 namespace node_tree_sitter {
 
@@ -16,8 +17,10 @@ Nan::Persistent<String> start_position_key;
 Nan::Persistent<String> end_index_key;
 Nan::Persistent<String> end_position_key;
 
-static unsigned BYTES_PER_CHARACTER = 2;
-static uint32_t *point_transfer_buffer;
+namespace {
+  const unsigned BYTES_PER_CHARACTER = 2;
+  uint32_t *point_transfer_buffer;
+} // namespace
 
 void InitConversions(Local<Object> exports) {
   row_key.Reset(Nan::Persistent<String>(Nan::New("row").ToLocalChecked()));
@@ -27,7 +30,7 @@ void InitConversions(Local<Object> exports) {
   end_index_key.Reset(Nan::Persistent<String>(Nan::New("endIndex").ToLocalChecked()));
   end_position_key.Reset(Nan::Persistent<String>(Nan::New("endPosition").ToLocalChecked()));
 
-  point_transfer_buffer = static_cast<uint32_t *>(malloc(2 * sizeof(uint32_t)));
+  point_transfer_buffer = new uint32_t[2];
 
   #if defined(_MSC_VER) && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
     auto nodeBuffer = node::Buffer::New(Isolate::GetCurrent(), (char *)point_transfer_buffer, 2 * sizeof(uint32_t), [](char *data, void *hint) {}, nullptr)

--- a/src/conversions.h
+++ b/src/conversions.h
@@ -1,9 +1,10 @@
 #ifndef NODE_TREE_SITTER_CONVERSIONS_H_
 #define NODE_TREE_SITTER_CONVERSIONS_H_
 
+#include "tree_sitter/api.h"
+
 #include <nan.h>
 #include <v8.h>
-#include <tree_sitter/api.h>
 
 namespace node_tree_sitter {
 

--- a/src/language.h
+++ b/src/language.h
@@ -1,20 +1,19 @@
 #ifndef NODE_TREE_SITTER_LANGUAGE_H_
 #define NODE_TREE_SITTER_LANGUAGE_H_
 
-#include <nan.h>
-#include <v8.h>
-#include <node_object_wrap.h>
-#include <tree_sitter/api.h>
+#include "tree_sitter/api.h"
 #include "./tree.h"
 
-namespace node_tree_sitter {
-namespace language_methods {
+#include <nan.h>
+#include <node_object_wrap.h>
+#include <v8.h>
+
+namespace node_tree_sitter::language_methods {
 
 void Init(v8::Local<v8::Object>);
 
 const TSLanguage *UnwrapLanguage(const v8::Local<v8::Value> &);
 
-}  // namespace language_methods
-}  // namespace node_tree_sitter
+} // namespace node_tree_sitter::language_methods
 
 #endif  // NODE_TREE_SITTER_LANGUAGE_H_

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -1,9 +1,10 @@
 #include "./logger.h"
+#include "./util.h"
+#include "tree_sitter/api.h"
+
+#include <nan.h>
 #include <string>
 #include <v8.h>
-#include <nan.h>
-#include <tree_sitter/api.h>
-#include "./util.h"
 
 namespace node_tree_sitter {
 
@@ -11,10 +12,11 @@ using namespace v8;
 using std::string;
 
 void Logger::Log(void *payload, TSLogType type, const char *message_str) {
-  Logger *debugger = (Logger *)payload;
+  auto *debugger = static_cast<Logger *>(payload);
   Local<Function> fn = Nan::New(debugger->func);
-  if (!fn->IsFunction())
+  if (!fn->IsFunction()) {
     return;
+  }
 
   string message(message_str);
   string param_sep = " ";
@@ -26,10 +28,11 @@ void Logger::Log(void *payload, TSLogType type, const char *message_str) {
 
   while (param_sep_pos != string::npos) {
     size_t key_pos = param_sep_pos + param_sep.size();
-    size_t value_sep_pos = message.find(":", key_pos);
+    size_t value_sep_pos = message.find(':', key_pos);
 
-    if (value_sep_pos == string::npos)
+    if (value_sep_pos == string::npos) {
       break;
+    }
 
     size_t val_pos = value_sep_pos + 1;
     param_sep = ", ";
@@ -57,9 +60,9 @@ void Logger::Log(void *payload, TSLogType type, const char *message_str) {
 
 TSLogger Logger::Make(Local<Function> func) {
   TSLogger result;
-  Logger *logger = new Logger();
+  auto *logger = new Logger();
   logger->func.Reset(Nan::Persistent<Function>(func));
-  result.payload = (void *)logger;
+  result.payload = static_cast<void *>(logger);
   result.log = Log;
   return result;
 }

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,9 +1,9 @@
 #ifndef NODE_TREE_SITTER_LOGGER_H_
 #define NODE_TREE_SITTER_LOGGER_H_
 
-#include <v8.h>
+#include "tree_sitter/api.h"
 #include <nan.h>
-#include <tree_sitter/api.h>
+#include <v8.h>
 
 namespace node_tree_sitter {
 

--- a/src/logger.h
+++ b/src/logger.h
@@ -7,7 +7,7 @@
 
 namespace node_tree_sitter {
 
-class Logger {
+class Logger final {
  public:
   static TSLogger Make(v8::Local<v8::Function>);
   Nan::Persistent<v8::Function> func;

--- a/src/lookaheaditerator.cc
+++ b/src/lookaheaditerator.cc
@@ -1,0 +1,176 @@
+#include "./lookaheaditerator.h"
+#include "./language.h"
+#include "./util.h"
+
+#include <nan.h>
+#include <tree_sitter/api.h>
+#include <v8.h>
+
+namespace node_tree_sitter {
+
+using namespace v8;
+
+Nan::Persistent<Function> LookaheadIterator::constructor;
+Nan::Persistent<FunctionTemplate> LookaheadIterator::constructor_template;
+
+void LookaheadIterator::Init(Local<Object> exports) {
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+  Local<String> class_name = Nan::New("LookaheadIterator").ToLocalChecked();
+  tpl->SetClassName(class_name);
+
+  GetterPair getters[] = {
+    {"currentSymbol", CurrentSymbol},
+    {"currentSymbolName", CurrentSymbolName},
+  };
+
+  FunctionPair methods[] = {
+    {"reset", Reset},
+    {"resetState", ResetState},
+    {"next", Next},
+    {"iterNames", IterNames},
+  };
+
+  for (auto &getter : getters) {
+    Nan::SetAccessor(
+      tpl->InstanceTemplate(),
+      Nan::New(getter.name).ToLocalChecked(),
+      getter.callback
+    );
+  }
+
+  for (auto &method : methods) {
+    Nan::SetPrototypeMethod(tpl, method.name, method.callback);
+  }
+
+  Local<Function> ctor = Nan::GetFunction(tpl).ToLocalChecked();
+
+  constructor_template.Reset(tpl);
+  constructor.Reset(ctor);
+  Nan::Set(exports, class_name, ctor);
+}
+
+LookaheadIterator::LookaheadIterator(TSLookaheadIterator *iterator) : iterator_(iterator) {}
+
+LookaheadIterator::~LookaheadIterator() {
+  ts_lookahead_iterator_delete(iterator_);
+}
+
+Local<Value> LookaheadIterator::NewInstance(TSLookaheadIterator *iterator) {
+  if (iterator != nullptr) {
+    Local<Object> self;
+    MaybeLocal<Object> maybe_self = Nan::NewInstance(Nan::New(constructor));
+    if (maybe_self.ToLocal(&self)) {
+      (new LookaheadIterator(iterator))->Wrap(self);
+      return self;
+    }
+  }
+  return Nan::Null();
+}
+
+LookaheadIterator *LookaheadIterator::UnwrapLookaheadIterator(const v8::Local<v8::Value> &value) {
+  if (!value->IsObject()) {
+    return nullptr;
+  }
+  Local<Object> js_iterator = Local<Object>::Cast(value);
+  if (!Nan::New(constructor_template)->HasInstance(js_iterator)) {
+    return nullptr;
+  }
+  return ObjectWrap::Unwrap<LookaheadIterator>(js_iterator);
+}
+
+void LookaheadIterator::New(const Nan::FunctionCallbackInfo<v8::Value> &info) {
+  if (!info.IsConstructCall()) {
+    Local<Object> self;
+    MaybeLocal<Object> maybe_self = Nan::NewInstance(Nan::New(constructor));
+    if (maybe_self.ToLocal(&self)) {
+      info.GetReturnValue().Set(self);
+    } else {
+      info.GetReturnValue().Set(Nan::Null());
+    }
+    return;
+  }
+
+  const TSLanguage *language = language_methods::UnwrapLanguage(info[0]);
+
+  if (language == nullptr) {
+    Nan::ThrowError("Missing language argument");
+    return;
+  }
+
+  if (!info[1]->IsNumber()) {
+    Nan::ThrowError("Missing state argument");
+    return;
+  }
+  TSStateId state = Nan::To<uint32_t>(info[1]).ToChecked();
+
+  TSLookaheadIterator *iterator = ts_lookahead_iterator_new(language, state);
+  if (iterator == nullptr) {
+    Nan::ThrowError("Invalid state argument");
+    return;
+  }
+  auto self = info.This();
+  auto *lookahead_iterator_wrapper = new LookaheadIterator(ts_lookahead_iterator_new(language, state));
+  lookahead_iterator_wrapper->Wrap(self);
+
+  info.GetReturnValue().Set(self);
+}
+
+void LookaheadIterator::CurrentSymbolName(Local<String> /*prop*/, const Nan::PropertyCallbackInfo<Value> &info) {
+  LookaheadIterator *iterator = UnwrapLookaheadIterator(info.This());
+  const char *name = ts_lookahead_iterator_current_symbol_name(iterator->iterator_);
+  info.GetReturnValue().Set(Nan::New(name).ToLocalChecked());
+}
+
+void LookaheadIterator::CurrentSymbol(Local<String>  /*prop*/, const Nan::PropertyCallbackInfo<Value> &info) {
+  LookaheadIterator *iterator = UnwrapLookaheadIterator(info.This());
+  TSSymbol symbol = ts_lookahead_iterator_current_symbol(iterator->iterator_);
+  info.GetReturnValue().Set(Nan::New(symbol));
+}
+
+void LookaheadIterator::Reset(const Nan::FunctionCallbackInfo<Value> &info) {
+  LookaheadIterator *iterator = UnwrapLookaheadIterator(info.This());
+  const TSLanguage *language = language_methods::UnwrapLanguage(info[0]);
+  if (language == nullptr) {
+    Nan::ThrowError("Invalid language argument");
+    return;
+  }
+  if (!info[1]->IsNumber()) {
+    Nan::ThrowError("Missing state argument");
+    return;
+  }
+  TSStateId state = Nan::To<uint32_t>(info[1]).ToChecked();
+  info.GetReturnValue().Set(Nan::New(ts_lookahead_iterator_reset(iterator->iterator_, language, state)));
+}
+
+void LookaheadIterator::ResetState(const Nan::FunctionCallbackInfo<Value> &info) {
+  LookaheadIterator *iterator = UnwrapLookaheadIterator(info.This());
+  if (!info[0]->IsNumber()) {
+    Nan::ThrowError("Missing state argument");
+    return;
+  }
+  TSStateId state = Nan::To<uint32_t>(info[0]).ToChecked();
+  info.GetReturnValue().Set(Nan::New(ts_lookahead_iterator_reset_state(iterator->iterator_, state)));
+}
+
+void LookaheadIterator::Next(const Nan::FunctionCallbackInfo<Value> &info) {
+  LookaheadIterator *iterator = UnwrapLookaheadIterator(info.This());
+  bool result = ts_lookahead_iterator_next(iterator->iterator_);
+  if (!result) {
+    info.GetReturnValue().Set(Nan::Null());
+    return;
+  }
+  info.GetReturnValue().Set(Nan::New(ts_lookahead_iterator_current_symbol(iterator->iterator_)));
+}
+
+void LookaheadIterator::IterNames(const Nan::FunctionCallbackInfo<Value> &info) {
+  LookaheadIterator *iterator = UnwrapLookaheadIterator(info.This());
+  auto result = Nan::New<Array>();
+  while (ts_lookahead_iterator_next(iterator->iterator_)) {
+    const char *name = ts_lookahead_iterator_current_symbol_name(iterator->iterator_);
+    Nan::Set(result, result->Length(), Nan::New(name).ToLocalChecked());
+  }
+  info.GetReturnValue().Set(result);
+}
+
+} // namespace node_tree_sitter

--- a/src/lookaheaditerator.h
+++ b/src/lookaheaditerator.h
@@ -1,0 +1,41 @@
+#ifndef NODE_TREE_SITTER_LOOKAHEAD_ITERATOR_H_
+#define NODE_TREE_SITTER_LOOKAHEAD_ITERATOR_H_
+
+#include "tree_sitter/api.h"
+
+#include <nan.h>
+#include <node_object_wrap.h>
+#include <v8.h>
+
+namespace node_tree_sitter {
+
+class LookaheadIterator final : public Nan::ObjectWrap {
+public:
+  static void Init(v8::Local<v8::Object> exports);
+  static v8::Local<v8::Value> NewInstance(TSLookaheadIterator *);
+  static LookaheadIterator *UnwrapLookaheadIterator(const v8::Local<v8::Value> &);
+
+  TSLookaheadIterator *iterator_;
+
+private:
+  explicit LookaheadIterator(TSLookaheadIterator *);
+  ~LookaheadIterator() final;
+
+  static void New(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void Reset(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void ResetState(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void Next(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void IterNames(const Nan::FunctionCallbackInfo<v8::Value> &);
+
+  static void CurrentSymbol(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
+  static void CurrentSymbolName(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
+
+  static Nan::Persistent<v8::Function> constructor;
+  static Nan::Persistent<v8::FunctionTemplate> constructor_template;
+};
+
+} // namespace node_tree_sitter
+
+
+
+#endif  // NODE_TREE_SITTER_LOOKAHEAD_ITERATOR_H_

--- a/src/node.h
+++ b/src/node.h
@@ -1,35 +1,32 @@
 #ifndef NODE_TREE_SITTER_NODE_H_
 #define NODE_TREE_SITTER_NODE_H_
 
-#include <nan.h>
-#include <v8.h>
-#include <node_object_wrap.h>
-#include <tree_sitter/api.h>
+#include "tree_sitter/api.h"
 #include "./tree.h"
 
-using namespace v8;
+#include <nan.h>
+#include <node_object_wrap.h>
+#include <v8.h>
 
-namespace node_tree_sitter {
-namespace node_methods {
+namespace node_tree_sitter::node_methods {
 
 void Init(v8::Local<v8::Object>);
 void MarshalNode(const Nan::FunctionCallbackInfo<v8::Value> &info, const Tree *, TSNode);
-Local<Value> GetMarshalNode(const Nan::FunctionCallbackInfo<Value> &info, const Tree *tree, TSNode node);
-Local<Value> GetMarshalNodes(const Nan::FunctionCallbackInfo<Value> &info, const Tree *tree, const TSNode *nodes, uint32_t node_count);
+v8::Local<v8::Value> GetMarshalNode(const Nan::FunctionCallbackInfo<v8::Value> &info, const Tree *tree, TSNode node);
+v8::Local<v8::Value> GetMarshalNodes(const Nan::FunctionCallbackInfo<v8::Value> &info, const Tree *tree, const TSNode *nodes, uint32_t node_count);
 TSNode UnmarshalNode(const Tree *tree);
 
 static inline const void *UnmarshalNodeId(const uint32_t *buffer) {
-  const void *result;
+  const void *result = nullptr;
   memcpy(&result, buffer, sizeof(result));
   return result;
 }
 
-static inline void MarshalNodeId(const void *id, uint32_t *buffer) {
+static inline void MarshalNodeId(const void *node_id, uint32_t *buffer) {
   memset(buffer, 0, sizeof(uint64_t));
-  memcpy(buffer, &id, sizeof(id));
+  memcpy(buffer, &node_id, sizeof(node_id));
 }
 
-}  // namespace node_methods
-}  // namespace node_tree_sitter
+} // namespace node_tree_sitter::node_methods
 
 #endif  // NODE_TREE_SITTER_NODE_H_

--- a/src/parser.h
+++ b/src/parser.h
@@ -1,22 +1,22 @@
 #ifndef NODE_TREE_SITTER_PARSER_H_
 #define NODE_TREE_SITTER_PARSER_H_
 
-#include <v8.h>
+#include "tree_sitter/api.h"
+
 #include <nan.h>
 #include <node_object_wrap.h>
-#include <tree_sitter/api.h>
+#include <v8.h>
 
 namespace node_tree_sitter {
 
-class Parser : public Nan::ObjectWrap {
+class Parser final : public Nan::ObjectWrap {
  public:
   static void Init(v8::Local<v8::Object> exports);
 
-  TSParser *parser_;
 
  private:
   explicit Parser();
-  ~Parser();
+  ~Parser() final;
 
   static void New(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void SetLanguage(const Nan::FunctionCallbackInfo<v8::Value> &);
@@ -25,6 +25,7 @@ class Parser : public Nan::ObjectWrap {
   static void Parse(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void PrintDotGraphs(const Nan::FunctionCallbackInfo<v8::Value> &);
 
+  TSParser *parser_;
   static Nan::Persistent<v8::Function> constructor;
 };
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -11,8 +11,7 @@ namespace node_tree_sitter {
 
 class Parser final : public Nan::ObjectWrap {
  public:
-  static void Init(v8::Local<v8::Object> exports);
-
+   static void Init(v8::Local<v8::Object> exports);
 
  private:
   explicit Parser();
@@ -20,10 +19,14 @@ class Parser final : public Nan::ObjectWrap {
 
   static void New(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void SetLanguage(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void Parse(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void IncludedRanges(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void TimeoutMicros(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void SetTimeoutMicros(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void GetLogger(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void SetLogger(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void Parse(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void PrintDotGraphs(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void Reset(const Nan::FunctionCallbackInfo<v8::Value> &);
 
   TSParser *parser_;
   static Nan::Persistent<v8::Function> constructor;

--- a/src/query.cc
+++ b/src/query.cc
@@ -42,8 +42,8 @@ void Query::Init(Local<Object> exports) {
     {"_getPredicates", GetPredicates},
   };
 
-  for (size_t i = 0; i < length_of_array(methods); i++) {
-    Nan::SetPrototypeMethod(tpl, methods[i].name, methods[i].callback);
+  for (auto & method : methods) {
+    Nan::SetPrototypeMethod(tpl, method.name, method.callback);
   }
 
   Local<Function> ctor = Nan::GetFunction(tpl).ToLocalChecked();

--- a/src/query.h
+++ b/src/query.h
@@ -5,7 +5,7 @@
 #include <nan.h>
 #include <node_object_wrap.h>
 #include <unordered_map>
-#include <tree_sitter/api.h>
+#include "tree_sitter/api.h"
 
 namespace node_tree_sitter {
 

--- a/src/query.h
+++ b/src/query.h
@@ -1,15 +1,15 @@
 #ifndef NODE_TREE_SITTER_QUERY_H_
 #define NODE_TREE_SITTER_QUERY_H_
 
-#include <v8.h>
+#include "tree_sitter/api.h"
+
 #include <nan.h>
 #include <node_object_wrap.h>
-#include <unordered_map>
-#include "tree_sitter/api.h"
+#include <v8.h>
 
 namespace node_tree_sitter {
 
-class Query : public Nan::ObjectWrap {
+class Query final : public Nan::ObjectWrap {
  public:
   static void Init(v8::Local<v8::Object> exports);
   static v8::Local<v8::Value> NewInstance(TSQuery *);
@@ -19,18 +19,26 @@ class Query : public Nan::ObjectWrap {
 
  private:
   explicit Query(TSQuery *);
-  ~Query();
+  ~Query() final;
 
   static void New(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void Matches(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void Captures(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void GetPredicates(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void DisableCapture(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void DisablePattern(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void IsPatternGuaranteedAtStep(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void IsPatternRooted(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void IsPatternNonLocal(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void StartIndexForPattern(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void DidExceedMatchLimit(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void MatchLimit(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
 
   static TSQueryCursor *ts_query_cursor;
   static Nan::Persistent<v8::Function> constructor;
   static Nan::Persistent<v8::FunctionTemplate> constructor_template;
 };
 
-}  // namespace node_tree_sitter
+} // namespace node_tree_sitter
 
 #endif  // NODE_TREE_SITTER_QUERY_H_

--- a/src/tree.h
+++ b/src/tree.h
@@ -12,10 +12,6 @@ namespace node_tree_sitter {
 
 class Tree final : public Nan::ObjectWrap {
  public:
-  Tree(const Tree &);
-  Tree(Tree &&) noexcept;
-  Tree &operator=(const Tree &);
-  Tree &operator=(Tree &&) noexcept;
   static void Init(v8::Local<v8::Object> exports);
   static v8::Local<v8::Value> NewInstance(TSTree *);
   static const Tree *UnwrapTree(const v8::Local<v8::Value> &);
@@ -36,9 +32,11 @@ class Tree final : public Nan::ObjectWrap {
   static void New(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void Edit(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void RootNode(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void RootNodeWithOffset(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void PrintDotGraph(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void GetEditedRange(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void GetChangedRanges(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void GetIncludedRanges(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void CacheNode(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void CacheNodes(const Nan::FunctionCallbackInfo<v8::Value> &);
 

--- a/src/tree.h
+++ b/src/tree.h
@@ -1,16 +1,21 @@
 #ifndef NODE_TREE_SITTER_TREE_H_
 #define NODE_TREE_SITTER_TREE_H_
 
-#include <v8.h>
+#include "tree_sitter/api.h"
+
 #include <nan.h>
 #include <node_object_wrap.h>
 #include <unordered_map>
-#include <tree_sitter/api.h>
+#include <v8.h>
 
 namespace node_tree_sitter {
 
-class Tree : public Nan::ObjectWrap {
+class Tree final : public Nan::ObjectWrap {
  public:
+  Tree(const Tree &);
+  Tree(Tree &&) noexcept;
+  Tree &operator=(const Tree &);
+  Tree &operator=(Tree &&) noexcept;
   static void Init(v8::Local<v8::Object> exports);
   static v8::Local<v8::Value> NewInstance(TSTree *);
   static const Tree *UnwrapTree(const v8::Local<v8::Value> &);
@@ -26,7 +31,7 @@ class Tree : public Nan::ObjectWrap {
 
  private:
   explicit Tree(TSTree *);
-  ~Tree();
+  ~Tree() final;
 
   static void New(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void Edit(const Nan::FunctionCallbackInfo<v8::Value> &);

--- a/src/tree_cursor.cc
+++ b/src/tree_cursor.cc
@@ -1,11 +1,12 @@
 #include "./tree_cursor.h"
-#include <nan.h>
-#include <tree_sitter/api.h>
-#include <v8.h>
-#include "./util.h"
 #include "./conversions.h"
 #include "./node.h"
 #include "./tree.h"
+#include "./util.h"
+#include "tree_sitter/api.h"
+
+#include <nan.h>
+#include <v8.h>
 
 namespace node_tree_sitter {
 
@@ -39,15 +40,15 @@ void TreeCursor::Init(v8::Local<v8::Object> exports) {
     {"reset", Reset},
   };
 
-  for (size_t i = 0; i < length_of_array(getters); i++) {
+  for (auto & getter : getters) {
     Nan::SetAccessor(
       tpl->InstanceTemplate(),
-      Nan::New(getters[i].name).ToLocalChecked(),
-      getters[i].callback);
+      Nan::New(getter.name).ToLocalChecked(),
+      getter.callback);
   }
 
-  for (size_t i = 0; i < length_of_array(methods); i++) {
-    Nan::SetPrototypeMethod(tpl, methods[i].name, methods[i].callback);
+  for (auto & method : methods) {
+    Nan::SetPrototypeMethod(tpl, method.name, method.callback);
   }
 
   Local<Function> constructor_local = Nan::GetFunction(tpl).ToLocalChecked();
@@ -61,9 +62,8 @@ Local<Value> TreeCursor::NewInstance(TSTreeCursor cursor) {
   if (maybe_self.ToLocal(&self)) {
     (new TreeCursor(cursor))->Wrap(self);
     return self;
-  } else {
-    return Nan::Null();
   }
+  return Nan::Null();
 }
 
 TreeCursor::TreeCursor(TSTreeCursor cursor) : cursor_(cursor) {}
@@ -75,19 +75,19 @@ void TreeCursor::New(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 void TreeCursor::GotoParent(const Nan::FunctionCallbackInfo<Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   bool result = ts_tree_cursor_goto_parent(&cursor->cursor_);
   info.GetReturnValue().Set(Nan::New(result));
 }
 
 void TreeCursor::GotoFirstChild(const Nan::FunctionCallbackInfo<Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   bool result = ts_tree_cursor_goto_first_child(&cursor->cursor_);
   info.GetReturnValue().Set(Nan::New(result));
 }
 
 void TreeCursor::GotoFirstChildForIndex(const Nan::FunctionCallbackInfo<Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   auto maybe_index = Nan::To<uint32_t>(info[0]);
   if (maybe_index.IsNothing()) {
     Nan::ThrowTypeError("Argument must be an integer");
@@ -103,25 +103,25 @@ void TreeCursor::GotoFirstChildForIndex(const Nan::FunctionCallbackInfo<Value> &
 }
 
 void TreeCursor::GotoNextSibling(const Nan::FunctionCallbackInfo<Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   bool result = ts_tree_cursor_goto_next_sibling(&cursor->cursor_);
   info.GetReturnValue().Set(Nan::New(result));
 }
 
 void TreeCursor::StartPosition(const Nan::FunctionCallbackInfo<Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
   TransferPoint(ts_node_start_point(node));
 }
 
 void TreeCursor::EndPosition(const Nan::FunctionCallbackInfo<Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
   TransferPoint(ts_node_end_point(node));
 }
 
 void TreeCursor::CurrentNode(const Nan::FunctionCallbackInfo<Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   Local<String> key = Nan::New<String>("tree").ToLocalChecked();
   const Tree *tree = Tree::UnwrapTree(Nan::Get(info.This(), key).ToLocalChecked());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
@@ -129,51 +129,51 @@ void TreeCursor::CurrentNode(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 void TreeCursor::Reset(const Nan::FunctionCallbackInfo<Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   Local<String> key = Nan::New<String>("tree").ToLocalChecked();
   const Tree *tree = Tree::UnwrapTree(Nan::Get(info.This(), key).ToLocalChecked());
   TSNode node = node_methods::UnmarshalNode(tree);
   ts_tree_cursor_reset(&cursor->cursor_, node);
 }
 
-void TreeCursor::NodeType(v8::Local<v8::String> prop, const Nan::PropertyCallbackInfo<v8::Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+void TreeCursor::NodeType(v8::Local<v8::String>  /*prop*/, const Nan::PropertyCallbackInfo<v8::Value> &info) {
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
   info.GetReturnValue().Set(Nan::New(ts_node_type(node)).ToLocalChecked());
 }
 
-void TreeCursor::NodeIsNamed(v8::Local<v8::String> prop, const Nan::PropertyCallbackInfo<v8::Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+void TreeCursor::NodeIsNamed(v8::Local<v8::String>  /*prop*/, const Nan::PropertyCallbackInfo<v8::Value> &info) {
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
 
   info.GetReturnValue().Set(Nan::New(ts_node_is_named(node)));
 }
 
-void TreeCursor::NodeIsMissing(v8::Local<v8::String> prop, const Nan::PropertyCallbackInfo<v8::Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+void TreeCursor::NodeIsMissing(v8::Local<v8::String>  /*prop*/, const Nan::PropertyCallbackInfo<v8::Value> &info) {
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
 
   info.GetReturnValue().Set(Nan::New(ts_node_is_missing(node)));
 }
 
-void TreeCursor::CurrentFieldName(v8::Local<v8::String> prop, const Nan::PropertyCallbackInfo<v8::Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+void TreeCursor::CurrentFieldName(v8::Local<v8::String>  /*prop*/, const Nan::PropertyCallbackInfo<v8::Value> &info) {
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   const char *field_name = ts_tree_cursor_current_field_name(&cursor->cursor_);
-  if (field_name) {
+  if (field_name != nullptr) {
     info.GetReturnValue().Set(Nan::New(field_name).ToLocalChecked());
   }
 }
 
-void TreeCursor::StartIndex(v8::Local<v8::String> prop, const Nan::PropertyCallbackInfo<v8::Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+void TreeCursor::StartIndex(v8::Local<v8::String>  /*prop*/, const Nan::PropertyCallbackInfo<v8::Value> &info) {
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
   info.GetReturnValue().Set(ByteCountToJS(ts_node_start_byte(node)));
 }
 
-void TreeCursor::EndIndex(v8::Local<v8::String> prop, const Nan::PropertyCallbackInfo<v8::Value> &info) {
-  TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
+void TreeCursor::EndIndex(v8::Local<v8::String>  /*prop*/, const Nan::PropertyCallbackInfo<v8::Value> &info) {
+  auto *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
   info.GetReturnValue().Set(ByteCountToJS(ts_node_end_byte(node)));
 }
 
-}
+} // namespace node_tree_sitter

--- a/src/tree_cursor.h
+++ b/src/tree_cursor.h
@@ -4,18 +4,18 @@
 #include <v8.h>
 #include <nan.h>
 #include <node_object_wrap.h>
-#include <tree_sitter/api.h>
+#include "tree_sitter/api.h"
 
 namespace node_tree_sitter {
 
-class TreeCursor : public Nan::ObjectWrap {
+class TreeCursor final : public Nan::ObjectWrap {
  public:
   static void Init(v8::Local<v8::Object> exports);
   static v8::Local<v8::Value> NewInstance(TSTreeCursor);
 
  private:
   explicit TreeCursor(TSTreeCursor);
-  ~TreeCursor();
+  ~TreeCursor() final;
 
   static void New(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void GotoParent(const Nan::FunctionCallbackInfo<v8::Value> &);

--- a/src/tree_cursor.h
+++ b/src/tree_cursor.h
@@ -12,29 +12,39 @@ class TreeCursor final : public Nan::ObjectWrap {
  public:
   static void Init(v8::Local<v8::Object> exports);
   static v8::Local<v8::Value> NewInstance(TSTreeCursor);
+  static TreeCursor *UnwrapTreeCursor(const v8::Local<v8::Value> &);
+
+  TSTreeCursor cursor_;
 
  private:
   explicit TreeCursor(TSTreeCursor);
   ~TreeCursor() final;
 
   static void New(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void GotoParent(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void GotoFirstChild(const Nan::FunctionCallbackInfo<v8::Value> &);
-  static void GotoFirstChildForIndex(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void GotoLastChild(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void GotoParent(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void GotoNextSibling(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void GotoPreviousSibling(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void GotoDescendant(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void GotoFirstChildForIndex(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void GotoFirstChildForPosition(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void StartPosition(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void EndPosition(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void CurrentNode(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void Reset(const Nan::FunctionCallbackInfo<v8::Value> &);
+  static void ResetTo(const Nan::FunctionCallbackInfo<v8::Value> &);
 
   static void NodeType(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
   static void NodeIsNamed(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
   static void NodeIsMissing(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
+  static void CurrentFieldId(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
   static void CurrentFieldName(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
+  static void CurrentDepth(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
+  static void CurrentDescendantIndex(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
   static void StartIndex(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
   static void EndIndex(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
 
-  TSTreeCursor cursor_;
   static Nan::Persistent<v8::Function> constructor;
   static Nan::Persistent<v8::FunctionTemplate> constructor_template;
 };

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,15 +1,9 @@
-#include <v8.h>
-#include <nan.h>
 #include "./util.h"
 
-namespace node_tree_sitter {
+#include <nan.h>
+#include <v8.h>
 
-bool instance_of(v8::Local<v8::Value> value, v8::Local<v8::Object> object) {
-  auto maybe_bool = value->InstanceOf(Nan::GetCurrentContext(), object);
-  if (maybe_bool.IsNothing())
-    return false;
-  return maybe_bool.FromJust();
-}
+namespace node_tree_sitter {
 
 v8::Local<v8::Object> GetGlobal(v8::Local<v8::Function>& callback) {
   #if (V8_MAJOR_VERSION > 9 || (V8_MAJOR_VERSION == 9 && V8_MINOR_VERSION > 4))

--- a/src/util.h
+++ b/src/util.h
@@ -1,12 +1,10 @@
 #ifndef NODE_TREE_SITTER_UTIL_H_
 #define NODE_TREE_SITTER_UTIL_H_
 
-#include <v8.h>
 #include <nan.h>
+#include <v8.h>
 
 namespace node_tree_sitter {
-
-#define length_of_array(a) (sizeof(a) / sizeof(a[0]))
 
 struct GetterPair {
   const char *name;
@@ -18,10 +16,8 @@ struct FunctionPair {
   Nan::FunctionCallback callback;
 };
 
-bool instance_of(v8::Local<v8::Value> value, v8::Local<v8::Object> object);
-
 v8::Local<v8::Object> GetGlobal(v8::Local<v8::Function>& callback);
 
-}  // namespace node_tree_sitter
+} // namespace node_tree_sitter
 
 #endif  // NODE_TREE_SITTER_UTIL_H_

--- a/test/lookahead_iterator_test.js
+++ b/test/lookahead_iterator_test.js
@@ -1,0 +1,38 @@
+const Parser = require("..");
+const Rust = require("tree-sitter-rust");
+const { assert } = require("chai");
+const {LookaheadIterator} = Parser;
+
+describe("LookaheadIterator", ()  => {
+
+  const parser = new Parser();
+  parser.setLanguage(Rust);
+
+  describe("test lookahead iterator", () => {
+    it("should iterate correctly", () => {
+      const tree = parser.parse("struct Stuff {}");
+
+      const cursor = tree.walk();
+
+      assert(cursor.gotoFirstChild()); // struct
+      assert(cursor.gotoFirstChild()); // struct keyword
+
+      const nextState = cursor.currentNode.nextParseState;
+      assert.notEqual(nextState, 0);
+      assert(cursor.gotoNextSibling()); // type_identifier
+      assert.equal(nextState, cursor.currentNode.parseState);
+      assert.equal(cursor.currentNode.grammarName,  "identifier");
+      assert.notEqual(cursor.currentNode.grammarId, cursor.currentNode.typeId);
+
+      const expectedSymbols = ["identifier", "block_comment", "line_comment"]
+      const lookahead = new LookaheadIterator(Rust, nextState);
+      assert.deepEqual(lookahead.iterNames(), expectedSymbols);
+
+      assert(lookahead.resetState(nextState));
+      assert.deepEqual(lookahead.iterNames(), expectedSymbols);
+
+      assert(lookahead.reset(Rust, nextState));
+      assert.deepEqual(lookahead.iterNames(), expectedSymbols);
+    });
+  });
+});

--- a/test/node_test.js
+++ b/test/node_test.js
@@ -1,6 +1,40 @@
 const Parser = require("..");
+const C = require('tree-sitter-c');
+const EmbeddedTemplate = require('tree-sitter-embedded-template');
 const JavaScript = require('tree-sitter-javascript');
+const JSON = require('tree-sitter-json');
+const Python = require('tree-sitter-python');
 const { assert } = require("chai");
+
+const JSON_EXAMPLE = `
+
+[
+  123,
+  false,
+  {
+    "x": null
+  }
+]
+`
+
+function getAllNodes(tree) {
+  const result = [];
+  let visitedChildren = false;
+  let cursor = tree.walk();
+  while (true) {
+    if (!visitedChildren) {
+      result.push(cursor.currentNode);
+      if (!cursor.gotoFirstChild()) {
+        visitedChildren = true;
+      }
+    } else if (cursor.gotoNextSibling()) {
+      visitedChildren = false;
+    } else if (!cursor.gotoParent()) {
+      break;
+    }
+  }
+  return result;
+}
 
 describe("Node", () => {
   let parser;
@@ -51,6 +85,171 @@ describe("Node", () => {
     })
   });
 
+  describe(".child", () => {
+    it("returns the child at the given index", () => {
+      parser.setLanguage(JSON);
+      const tree = parser.parse(JSON_EXAMPLE);
+      const arrayNode = tree.rootNode.child(0);
+
+      assert.equal(arrayNode.type, "array");
+      assert.equal(arrayNode.namedChildCount, 3);
+      assert.equal(arrayNode.startIndex, JSON_EXAMPLE.indexOf("["));
+      assert.equal(arrayNode.endIndex, JSON_EXAMPLE.indexOf("]") + 1);
+      assert.deepEqual(arrayNode.startPosition, { row: 2, column: 0 });
+      assert.deepEqual(arrayNode.endPosition, { row: 8, column: 1 });
+      assert.equal(arrayNode.childCount, 7);
+
+      const leftBracketNode = arrayNode.child(0);
+      const numberNode = arrayNode.child(1);
+      const commaNode1 = arrayNode.child(2);
+      const falseNode = arrayNode.child(3);
+      const commaNode2 = arrayNode.child(4);
+      const objectNode = arrayNode.child(5);
+      const rightBracketNode = arrayNode.child(6);
+
+      assert.equal(leftBracketNode.type, "[");
+      assert.equal(numberNode.type, "number");
+      assert.equal(commaNode1.type, ",");
+      assert.equal(falseNode.type, "false");
+      assert.equal(commaNode2.type, ",");
+      assert.equal(objectNode.type, "object");
+      assert.equal(rightBracketNode.type, "]");
+
+      assert(!leftBracketNode.isNamed);
+      assert(numberNode.isNamed);
+      assert(!commaNode1.isNamed);
+      assert(falseNode.isNamed);
+      assert(!commaNode2.isNamed);
+      assert(objectNode.isNamed);
+      assert(!rightBracketNode.isNamed);
+
+      assert.equal(numberNode.startIndex, JSON_EXAMPLE.indexOf("123"));
+      assert.equal(numberNode.endIndex, JSON_EXAMPLE.indexOf("123") + 3);
+      assert.deepEqual(numberNode.startPosition, { row: 3, column: 2 });
+      assert.deepEqual(numberNode.endPosition, { row: 3, column: 5 });
+
+      assert.equal(falseNode.startIndex, JSON_EXAMPLE.indexOf("false"));
+      assert.equal(falseNode.endIndex, JSON_EXAMPLE.indexOf("false") + 5);
+      assert.deepEqual(falseNode.startPosition, { row: 4, column: 2 });
+      assert.deepEqual(falseNode.endPosition, { row: 4, column: 7 });
+
+      assert.equal(objectNode.startIndex, JSON_EXAMPLE.indexOf("{"));
+      assert.equal(objectNode.endIndex, JSON_EXAMPLE.indexOf("}") + 1);
+      assert.deepEqual(objectNode.startPosition, { row: 5, column: 2 });
+      assert.deepEqual(objectNode.endPosition, { row: 7, column: 3 });
+
+      assert.equal(objectNode.childCount, 3);
+      const leftBraceNode = objectNode.child(0);
+      const pairNode = objectNode.child(1);
+      const rightBraceNode = objectNode.child(2);
+
+      assert.equal(leftBraceNode.type, "{");
+      assert.equal(pairNode.type, "pair");
+      assert.equal(rightBraceNode.type, "}");
+
+      assert(!leftBraceNode.isNamed);
+      assert(pairNode.isNamed);
+      assert(!rightBraceNode.isNamed);
+
+      assert.equal(pairNode.startIndex, JSON_EXAMPLE.indexOf('"x"'));
+      assert.equal(pairNode.endIndex, JSON_EXAMPLE.indexOf("null") + 4);
+      assert.deepEqual(pairNode.startPosition, { row: 6, column: 4 });
+      assert.deepEqual(pairNode.endPosition, { row: 6, column: 13 });
+
+      assert.equal(pairNode.childCount, 3);
+      const stringNode = pairNode.child(0);
+      const colonNode = pairNode.child(1);
+      const nullNode = pairNode.child(2);
+
+      assert.equal(stringNode.type, "string");
+      assert.equal(colonNode.type, ":");
+      assert.equal(nullNode.type, "null");
+
+      assert(stringNode.isNamed);
+      assert(!colonNode.isNamed);
+      assert(nullNode.isNamed);
+
+      assert.equal(stringNode.startIndex, JSON_EXAMPLE.indexOf('"x"'));
+      assert.equal(stringNode.endIndex, JSON_EXAMPLE.indexOf('"x"') + 3);
+      assert.deepEqual(stringNode.startPosition, { row: 6, column: 4 });
+      assert.deepEqual(stringNode.endPosition, { row: 6, column: 7 });
+
+      assert.equal(nullNode.startIndex, JSON_EXAMPLE.indexOf("null"));
+      assert.equal(nullNode.endIndex, JSON_EXAMPLE.indexOf("null") + 4);
+      assert.deepEqual(nullNode.startPosition, { row: 6, column: 9 });
+      assert.deepEqual(nullNode.endPosition, { row: 6, column: 13 });
+
+      assert.equal(stringNode.parent, pairNode);
+      assert.equal(nullNode.parent, pairNode);
+      assert.equal(pairNode.parent, objectNode);
+      assert.equal(numberNode.parent, arrayNode);
+      assert.equal(falseNode.parent, arrayNode);
+      assert.equal(objectNode.parent, arrayNode);
+      assert.equal(arrayNode.parent, tree.rootNode);
+      assert.equal(tree.rootNode.parent, null);
+    });
+  });
+
+  describe(".namedChild", () => {
+    it("returns the named child at the given index", () => {
+      parser.setLanguage(JSON);
+      const tree = parser.parse(JSON_EXAMPLE);
+      const arrayNode = tree.rootNode.namedChild(0);
+
+      const numberNode = arrayNode.namedChild(0);
+      const falseNode = arrayNode.namedChild(1);
+      const objectNode = arrayNode.namedChild(2);
+
+      assert.equal(numberNode.type, "number");
+      assert.equal(numberNode.startIndex, JSON_EXAMPLE.indexOf("123"));
+      assert.equal(numberNode.endIndex, JSON_EXAMPLE.indexOf("123") + 3);
+      assert.deepEqual(numberNode.startPosition, { row: 3, column: 2 });
+      assert.deepEqual(numberNode.endPosition, { row: 3, column: 5 });
+
+      assert.equal(falseNode.type, "false");
+      assert.equal(falseNode.startIndex, JSON_EXAMPLE.indexOf("false"));
+      assert.equal(falseNode.endIndex, JSON_EXAMPLE.indexOf("false") + 5);
+      assert.deepEqual(falseNode.startPosition, { row: 4, column: 2 });
+      assert.deepEqual(falseNode.endPosition, { row: 4, column: 7 });
+
+      assert.equal(objectNode.type, "object");
+      assert.equal(objectNode.startIndex, JSON_EXAMPLE.indexOf("{"));
+      assert.deepEqual(objectNode.startPosition, { row: 5, column: 2 });
+      assert.deepEqual(objectNode.endPosition, { row: 7, column: 3 });
+
+      assert.equal(objectNode.namedChildCount, 1);
+
+      const pairNode = objectNode.namedChild(0);
+      assert.equal(pairNode.type, "pair");
+      assert.equal(pairNode.startIndex, JSON_EXAMPLE.indexOf('"x"'));
+      assert.equal(pairNode.endIndex, JSON_EXAMPLE.indexOf("null") + 4);
+      assert.deepEqual(pairNode.startPosition, { row: 6, column: 4 });
+      assert.deepEqual(pairNode.endPosition, { row: 6, column: 13 });
+
+      const stringNode = pairNode.namedChild(0);
+      const nullNode = pairNode.namedChild(1);
+
+      assert.equal(stringNode.startIndex, JSON_EXAMPLE.indexOf('"x"'));
+      assert.equal(stringNode.endIndex, JSON_EXAMPLE.indexOf('"x"') + 3);
+      assert.deepEqual(stringNode.startPosition, { row: 6, column: 4 });
+      assert.deepEqual(stringNode.endPosition, { row: 6, column: 7 });
+
+      assert.equal(nullNode.startIndex, JSON_EXAMPLE.indexOf("null"));
+      assert.equal(nullNode.endIndex, JSON_EXAMPLE.indexOf("null") + 4);
+      assert.deepEqual(nullNode.startPosition, { row: 6, column: 9 });
+      assert.deepEqual(nullNode.endPosition, { row: 6, column: 13 });
+
+      assert.equal(stringNode.parent, pairNode);
+      assert.equal(nullNode.parent, pairNode);
+      assert.equal(pairNode.parent, objectNode);
+      assert.equal(numberNode.parent, arrayNode);
+      assert.equal(falseNode.parent, arrayNode);
+      assert.equal(objectNode.parent, arrayNode);
+      assert.equal(arrayNode.parent, tree.rootNode);
+      assert.equal(tree.rootNode.parent, null);
+    });
+  });
+
   describe(".children", () => {
     it("returns an array of child nodes", () => {
       const tree = parser.parse("x10 + 1000");
@@ -72,6 +271,74 @@ describe("Node", () => {
         ["identifier", "number"],
         sumNode.namedChildren.map(child => child.type)
       );
+    });
+  });
+
+  describe(".childrenForFieldName", () => {
+    it("returns an array of child nodes for the given field name", () => {
+      parser.setLanguage(Python);
+      const source = `
+        if one:
+            a()
+        elif two:
+            b()
+        elif three:
+            c()
+        elif four:
+            d()`
+
+      const tree = parser.parse(source);
+      const node = tree.rootNode.firstChild;
+      assert.equal(node.type, 'if_statement');
+      const cursor = tree.walk();
+      const alternatives = node.childrenForFieldName('alternative', cursor);
+      const alternative_texts = alternatives.map(n => {
+        const condition = n.childForFieldName('condition');
+        return source.slice(condition.startIndex, condition.endIndex);
+      });
+      assert.deepEqual(alternative_texts, ['two', 'three', 'four']);
+    });
+  });
+
+  describe(".childForFieldName", () => {
+    it("checks the parent node", () => {
+      const tree = parser.parse("foo(a().b[0].c.d.e())");
+      const callNode = tree.rootNode.firstNamedChild.firstNamedChild;
+      assert.equal(callNode.type, "call_expression");
+
+      // Regression test - when a field points to a hidden node (in this case, `_expression`)
+      // the hidden node should not be added to the node parent cache.
+      assert.equal(
+        callNode.childForFieldName("function").parent,
+        callNode
+      );
+    });
+
+    it("checks that extra hidden children are skipped", () => {
+      parser.setLanguage(Python);
+      const tree = parser.parse("while a:\n  pass");
+      const whileNode = tree.rootNode.firstChild;
+      assert.equal(whileNode.type, "while_statement");
+      assert.equal(whileNode.childForFieldName("body"), whileNode.child(3));
+    });
+  });
+
+  describe(".fieldNameForChild", () => {
+    it("returns the field name for the given child node", () => {
+      parser.setLanguage(C);
+      const tree = parser.parse("int w = x + y;");
+      const translation_unit_node = tree.rootNode;
+      const declaration_node = translation_unit_node.firstNamedChild;
+
+      const binary_expression_node = declaration_node
+                                      .childForFieldName("declarator")
+                                      .childForFieldName("value");
+
+      assert.equal(binary_expression_node.fieldNameForChild(0), "left");
+      assert.equal(binary_expression_node.fieldNameForChild(1), "operator");
+      assert.equal(binary_expression_node.fieldNameForChild(2), "right");
+      // Negative test - Not a valid child index
+      assert.equal(binary_expression_node.fieldNameForChild(3), null);
     });
   });
 
@@ -389,6 +656,19 @@ describe("Node", () => {
     });
   });
 
+  describe(".isExtra()", () => {
+    it("returns true if the node is an extra node like comments", () => {
+      const tree = parser.parse("foo(/* hi */);");
+      const node = tree.rootNode;
+      const comment_node = node.descendantForIndex(7, 7);
+
+      assert.equal(node.type, "program");
+      assert.equal(comment_node.type, "comment");
+      assert(!node.isExtra());
+      assert(comment_node.isExtra());
+    });
+  });
+
   describe(".text", () => {
     Object.entries({
       '.parse(String)': (parser, src) => parser.parse(src),
@@ -411,11 +691,172 @@ describe("Node", () => {
     )
   });
 
-  describe("VSCode", () => {
+  describe(".descendantCount", () => {
+    it("returns the number of descendants", () => {
+      parser.setLanguage(JSON);
+      const tree = parser.parse(JSON_EXAMPLE);
+      const valueNode = tree.rootNode;
+      const allNodes = getAllNodes(tree);
+
+      assert.equal(valueNode.descendantCount, allNodes.length);
+
+      const cursor = tree.walk();
+      for (let i = 0; i < allNodes.length; i++) {
+        const node = allNodes[i];
+        cursor.gotoDescendant(i)
+        assert.equal(cursor.currentNode, node, `index ${i}`);
+      }
+
+      for (let i = allNodes.length - 1; i >= 0; i--) {
+        const node = allNodes[i];
+        cursor.gotoDescendant(i)
+        assert.equal(cursor.currentNode, node, `rev index ${i}`);
+      }
+    });
+
+    it("tests a single node tree", () => {
+      parser.setLanguage(EmbeddedTemplate);
+      const tree = parser.parse("hello");
+
+      const nodes = getAllNodes(tree);
+      assert.equal(nodes.length, 2);
+      assert.equal(tree.rootNode.descendantCount, 2);
+
+      const cursor = tree.walk();
+
+      cursor.gotoDescendant(0);
+      assert.equal(cursor.currentDepth, 0);
+      assert.equal(cursor.currentNode, nodes[0]);
+
+      cursor.gotoDescendant(1);
+      assert.equal(cursor.currentDepth, 1);
+      assert.equal(cursor.currentNode, nodes[1]);
+    });
+  });
+
+  describe(".descendantFor{Index, Position}", () => {
+    it("returns the descendant at the given index", () => {
+      parser.setLanguage(JSON);
+      const tree = parser.parse(JSON_EXAMPLE);
+      const arrayNode = tree.rootNode;
+      
+      // Leaf node exactly matches the given bounds - index query
+      const colonIndex = JSON_EXAMPLE.indexOf(":");
+      let colonNode = arrayNode.descendantForIndex(colonIndex, colonIndex + 1);
+      assert.equal(colonNode.type, ":");
+      assert.equal(colonNode.startIndex, colonIndex);
+      assert.equal(colonNode.endIndex, colonIndex + 1);
+      assert.deepEqual(colonNode.startPosition, { row: 6, column: 7 });
+      assert.deepEqual(colonNode.endPosition, { row: 6, column: 8 });
+
+      // Leaf node exactly matches the given bounds - point query
+      colonNode = arrayNode.descendantForPosition({ row: 6, column: 7 }, { row: 6, column: 8 });
+      assert.equal(colonNode.type, ":");
+      assert.equal(colonNode.startIndex, colonIndex);
+      assert.equal(colonNode.endIndex, colonIndex + 1);
+      assert.deepEqual(colonNode.startPosition, { row: 6, column: 7 });
+      assert.deepEqual(colonNode.endPosition, { row: 6, column: 8 });
+
+      // The given point is between two adjacent leaf nodes - index query
+      colonNode = arrayNode.descendantForIndex(colonIndex, colonIndex);
+      assert.equal(colonNode.type, ":");
+      assert.equal(colonNode.startIndex, colonIndex);
+      assert.equal(colonNode.endIndex, colonIndex + 1);
+      assert.deepEqual(colonNode.startPosition, { row: 6, column: 7 });
+      assert.deepEqual(colonNode.endPosition, { row: 6, column: 8 });
+
+      // The given point is between two adjacent leaf nodes - point query
+      colonNode = arrayNode.descendantForPosition({ row: 6, column: 7 }, { row: 6, column: 7 });
+      assert.equal(colonNode.type, ":");
+      assert.equal(colonNode.startIndex, colonIndex);
+      assert.equal(colonNode.endIndex, colonIndex + 1);
+      assert.deepEqual(colonNode.startPosition, { row: 6, column: 7 });
+      assert.deepEqual(colonNode.endPosition, { row: 6, column: 8 });
+
+      // Leaf node starts at the lower bound, ends after the upper bound - index query
+      const stringIndex = JSON_EXAMPLE.indexOf('"x"');
+      let stringNode = arrayNode.descendantForIndex(stringIndex, stringIndex + 2);
+      assert.equal(stringNode.type, "string");
+      assert.equal(stringNode.startIndex, stringIndex);
+      assert.equal(stringNode.endIndex, stringIndex + 3);
+      assert.deepEqual(stringNode.startPosition, { row: 6, column: 4 });
+      assert.deepEqual(stringNode.endPosition, { row: 6, column: 7 });
+
+      // Leaf node starts at the lower bound, ends after the upper bound - point query
+      stringNode = arrayNode.descendantForPosition({ row: 6, column: 4 }, { row: 6, column: 6 });
+      assert.equal(stringNode.type, "string");
+      assert.equal(stringNode.startIndex, stringIndex);
+      assert.equal(stringNode.endIndex, stringIndex + 3);
+      assert.deepEqual(stringNode.startPosition, { row: 6, column: 4 });
+      assert.deepEqual(stringNode.endPosition, { row: 6, column: 7 });
+
+      // Leaf node starts before the lower bound, ends at the upper bound - index query
+      const nullIndex = JSON_EXAMPLE.indexOf("null");
+      let nullNode = arrayNode.descendantForIndex(nullIndex + 1, nullIndex + 4);
+      assert.equal(nullNode.type, "null");
+      assert.equal(nullNode.startIndex, nullIndex);
+      assert.equal(nullNode.endIndex, nullIndex + 4);
+      assert.deepEqual(nullNode.startPosition, { row: 6, column: 9 });
+      assert.deepEqual(nullNode.endPosition, { row: 6, column: 13 });
+
+      // Leaf node starts before the lower bound, ends at the upper bound - point query
+      nullNode = arrayNode.descendantForPosition({ row: 6, column: 11 }, { row: 6, column: 13 });
+      assert.equal(nullNode.type, "null");
+      assert.equal(nullNode.startIndex, nullIndex);
+      assert.equal(nullNode.endIndex, nullIndex + 4);
+      assert.deepEqual(nullNode.startPosition, { row: 6, column: 9 });
+      assert.deepEqual(nullNode.endPosition, { row: 6, column: 13 });
+
+      // The bounds span multiple leaf nodes - return the smallest node that does span it.
+      let pairNode = arrayNode.descendantForIndex(stringIndex + 2, stringIndex + 4);
+      assert.equal(pairNode.type, "pair");
+      assert.equal(pairNode.startIndex, stringIndex);
+      assert.equal(pairNode.endIndex, stringIndex + 9);
+      assert.deepEqual(pairNode.startPosition, { row: 6, column: 4 });
+      assert.deepEqual(pairNode.endPosition, { row: 6, column: 13 });
+
+      assert.equal(colonNode.parent, pairNode);
+
+      // No leaf spans the given range - return the smallest node that does span it.
+      pairNode = arrayNode.descendantForPosition({ row: 6, column: 6 }, { row: 6, column: 8 });
+      assert.equal(pairNode.type, "pair");
+      assert.equal(pairNode.startIndex, stringIndex);
+      assert.equal(pairNode.endIndex, stringIndex + 9);
+      assert.deepEqual(pairNode.startPosition, { row: 6, column: 4 });
+      assert.deepEqual(pairNode.endPosition, { row: 6, column: 13 });
+    });
+  });
+
+  describe("Numeric symbols respect simple aliases", () => {
+    it("should ensure numeric symbol ids for an alias match the normal id", () => {
+      parser.setLanguage(Python);
+
+      // Example 1:
+      // Python argument lists can contain "splat" arguments, which are not allowed within
+      // other expressions. This includes `parenthesized_list_splat` nodes like `(*b)`. These
+      // `parenthesized_list_splat` nodes are aliased as `parenthesized_expression`. Their numeric
+      // `symbol`, aka `kind_id` should match that of a normal `parenthesized_expression`.
+      const tree = parser.parse("(a((*b)))");
+      const root = tree.rootNode;
+      assert.equal(
+        root.toString(),
+        "(module (expression_statement (parenthesized_expression (call function: (identifier) arguments: (argument_list (parenthesized_expression (list_splat (identifier))))))))"
+      );
+
+      const outerExprNode = root.firstChild.firstChild;
+      assert.equal(outerExprNode.type, "parenthesized_expression");
+
+      const innerExprNode = outerExprNode.firstNamedChild.childForFieldName("arguments").firstNamedChild;
+      assert.equal(innerExprNode.type, "parenthesized_expression");
+      assert.equal(innerExprNode.typeId, outerExprNode.typeId);
+    });
+  });
+
+
+  describe("Property accesses", () => {
     it("shouldn't segfault when accessing properties on the prototype", () => {
       const tree = parser.parse('2 + 2');
       const nodePrototype = Object.getPrototypeOf(tree.rootNode);
-      // const nodePrototype = tree.rootNode.__proto__;
 
       const properties = [
         "type",
@@ -440,6 +881,7 @@ describe("Node", () => {
         "previousSibling",
         "previousNamedSibling",
       ];
+
       for (const property of properties) {
         assert.throws(() => { nodePrototype[property]; }, TypeError)
       }
@@ -462,6 +904,7 @@ describe("Node", () => {
         "descendantForPosition",
         "closest",
       ];
+
       for (const method of methods) {
         assert.throws(nodePrototype[method], TypeError)
       }

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -1,5 +1,7 @@
 const Parser = require("..");
+const HTML = require('tree-sitter-html');
 const JavaScript = require('tree-sitter-javascript');
+const JSON = require('tree-sitter-json');
 const { assert } = require("chai");
 
 describe("Parser", () => {
@@ -92,6 +94,29 @@ describe("Parser", () => {
     });
   });
 
+  describe(".printDotGraphs", () => {
+    beforeEach(() => {
+      parser.setLanguage(JavaScript);
+    });
+
+    it("prints a dot graph to the output file", () => {
+      const hasZeroIndexedRow = s => s.indexOf("position: 0,") !== -1;
+
+      const tmp = require("tmp");
+      const debugGraphFile = tmp.fileSync({ postfix: ".dot" });
+      parser.printDotGraphs(true, debugGraphFile.fd);
+      parser.parse("const zero = 0");
+
+      const fs = require('fs');
+      const logReader = fs.readFileSync(debugGraphFile.name, 'utf8').split('\n');
+      for (let line of logReader) {
+        assert.strictEqual(hasZeroIndexedRow(line), false, `Graph log output includes zero-indexed row: ${line}`);
+      }
+
+      debugGraphFile.removeCallback();
+    });
+  });
+
   describe(".parse", () => {
     beforeEach(() => {
       parser.setLanguage(JavaScript);
@@ -165,5 +190,440 @@ describe("Parser", () => {
         );
       })
     })
+
+    describe('invalid chars at eof', () => {
+      it('shows in the parse tree', () => {
+        parser.setLanguage(JSON);
+        const tree = parser.parse('\xdf');
+        assert.equal(tree.rootNode.toString(), "(document (ERROR (UNEXPECTED 223)))");
+      });
+    });
+
+    describe('unexpected null characters', () => {
+      it('has a null character in the source', () => {
+        parser.setLanguage(JavaScript);
+        const tree = parser.parse('var \0 something;')
+        assert.equal(
+          tree.rootNode.toString(),
+          "(program (variable_declaration (ERROR (UNEXPECTED '\\0')) (variable_declarator name: (identifier))))"
+        );
+      });
+    });
+
+    describe('parsing with a timeout', () => {
+      it('stops after a certain number of microseconds', () => {
+        parser.setLanguage(JSON);
+
+        // dont use Date.now(), we need microseconds
+        let startTime = performance.now() * 1000;
+        parser.setTimeoutMicros(1000);
+        let tree = parser.parse((offset, _) => offset === 0 ? " [" : ",0");
+        assert.equal(tree, null);
+        assert.isBelow(performance.now() * 1000 - startTime, 2000);
+
+        startTime = performance.now() * 1000;
+        parser.setTimeoutMicros(5000);
+        tree = parser.parse((offset, _) => offset === 0 ? " [" : ",0");
+        assert.equal(tree, null);
+        assert.isAbove(performance.now() * 1000 - startTime, 100);
+        assert.isBelow(performance.now() * 1000 - startTime, 10000);
+
+        parser.setTimeoutMicros(0);
+        tree = parser.parse((offset, _) => offset > 5000 ? "" : offset == 5000 ? "]" : ",0");
+        assert.equal(tree.rootNode.firstChild.type, "array");
+      });
+    });
+
+    describe('parsing with a timeout and reset', () => {
+      it('stops after a certain number of microseconds and resets the parser', () => {
+        parser.setLanguage(JSON);
+
+        parser.setTimeoutMicros(5);
+        let tree = parser.parse(
+          '["ok", 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]'
+        );
+        assert.equal(tree, null);
+
+        // Without calling reset, the parser continues from where it left off, so
+        // it does not see the changes to the beginning of the source code.
+        parser.setTimeoutMicros(0);
+        tree = parser.parse(
+          '[null, 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]'
+        );
+        assert.equal(tree.rootNode.firstNamedChild.firstNamedChild.type, "string");
+
+        parser.setTimeoutMicros(5);
+        tree = parser.parse(
+          '[\"ok\", 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]'
+        );
+        assert.equal(tree, null);
+
+        // By calling reset, we force the parser to start over from scratch so
+        // that it sees the changes to the beginning of the source code.
+        parser.setTimeoutMicros(0);
+        parser.reset();
+        tree = parser.parse(
+          '[null, 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]'
+        );
+        assert.equal(tree.rootNode.firstNamedChild.firstNamedChild.type, "null");
+      });
+    });
+
+    describe('parsing with a timeout and implicit reset', () => {
+      it('stops after a certain number of microseconds and resets the parser', () => {
+        parser.setLanguage(JavaScript);
+
+        parser.setTimeoutMicros(5);
+        let tree = parser.parse(
+          '[\"ok\", 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]'
+        );
+        assert.equal(tree, null);
+
+        // Changing the parser's language implicitly resets, discarding
+        // the previous partial parse.
+        parser.setLanguage(JSON);
+        parser.setTimeoutMicros(0);
+        tree = parser.parse(
+          '[null, 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]'
+        );
+        assert.equal(tree.rootNode.firstNamedChild.firstNamedChild.type, "null");
+      });
+    });
+
+    describe('parsing with a timeout and no completion', () => {
+      it('stops after a certain number of microseconds and returns before completion', () => {
+        parser.setLanguage(JavaScript);
+
+        parser.setTimeoutMicros(5);
+        let tree = parser.parse(
+          '[\"ok\", 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]'
+        );
+        assert.equal(tree, null);
+      });
+    });
+
+    describe('one included range', () => {
+      it('parses the text within a range', () => {
+        parser.setLanguage(HTML);
+        const sourceCode = "<span>hi</span><script>console.log('sup');</script>";
+        const htmlTree = parser.parse(sourceCode);
+        const scriptContentNode = htmlTree.rootNode.child(1).child(1);
+        assert.equal(scriptContentNode.type, "raw_text");
+
+        parser.setLanguage(JavaScript);
+        const jsTree = parser.parse(
+          sourceCode,
+          null,
+          {
+            includedRanges: [{
+              startIndex: scriptContentNode.startIndex,
+              endIndex: scriptContentNode.endIndex,
+              startPosition: scriptContentNode.startPosition,
+              endPosition: scriptContentNode.endPosition
+            }]
+          }
+        );
+
+        assert.equal(
+          jsTree.rootNode.toString(),
+          "(program (expression_statement (call_expression " +
+          "function: (member_expression object: (identifier) property: (property_identifier)) " +
+          "arguments: (arguments (string (string_fragment))))))"
+        );
+        assert.deepEqual(jsTree.rootNode.startPosition, { row: 0, column: sourceCode.indexOf('console') });
+      });
+    });
+
+    describe('multiple included ranges', () => {
+      it('parses the text within multiple ranges', () => {
+        parser.setLanguage(JavaScript);
+        const sourceCode = "html `<div>Hello, ${name.toUpperCase()}, it's <b>${now()}</b>.</div>`";
+        const jsTree = parser.parse(sourceCode);
+        const templateStringNode = jsTree.rootNode.descendantForIndex(sourceCode.indexOf('<div>'), sourceCode.indexOf('Hello'));
+        assert.equal(templateStringNode.type, "template_string");
+
+        const openQuoteNode = templateStringNode.child(0);
+        const interpolationNode1 = templateStringNode.child(1);
+        const interpolationNode2 = templateStringNode.child(2);
+        const closeQuoteNode = templateStringNode.child(3);
+
+        parser.setLanguage(HTML);
+        const htmlRanges = [
+          {
+            startIndex: openQuoteNode.endIndex,
+            startPosition: openQuoteNode.endPosition,
+            endIndex: interpolationNode1.startIndex,
+            endPosition: interpolationNode1.startPosition
+          },
+          {
+            startIndex: interpolationNode1.endIndex,
+            startPosition: interpolationNode1.endPosition,
+            endIndex: interpolationNode2.startIndex,
+            endPosition: interpolationNode2.startPosition
+          },
+          {
+            startIndex: interpolationNode2.endIndex,
+            startPosition: interpolationNode2.endPosition,
+            endIndex: closeQuoteNode.startIndex,
+            endPosition: closeQuoteNode.startPosition
+          },
+        ];
+        const htmlTree = parser.parse(sourceCode, null, { includedRanges: htmlRanges });
+
+        assert.equal(
+          htmlTree.rootNode.toString(),
+          "(fragment (element" +
+          " (start_tag (tag_name))" +
+          " (text)" +
+          " (element (start_tag (tag_name)) (end_tag (tag_name)))" +
+          " (text)" +
+          " (end_tag (tag_name))))"
+        );
+        assert.deepEqual(htmlTree.getIncludedRanges(), htmlRanges);
+
+        const divElementNode = htmlTree.rootNode.child(0);
+        const helloTextNode = divElementNode.child(1);
+        const bElementNode = divElementNode.child(2);
+        const bStartTagNode = bElementNode.child(0);
+        const bEndTagNode = bElementNode.child(1);
+
+        assert.equal(helloTextNode.type, "text");
+        assert.equal(helloTextNode.startIndex, sourceCode.indexOf('Hello'));
+        assert.equal(helloTextNode.endIndex, sourceCode.indexOf(' <b>'));
+
+        assert.equal(bStartTagNode.type, "start_tag");
+        assert.equal(bStartTagNode.startIndex, sourceCode.indexOf('<b>'));
+        assert.equal(bStartTagNode.endIndex, sourceCode.indexOf('${now()}'));
+
+        assert.equal(bEndTagNode.type, "end_tag");
+        assert.equal(bEndTagNode.startIndex, sourceCode.indexOf('</b>'));
+        assert.equal(bEndTagNode.endIndex, sourceCode.indexOf('.</div>'));
+      });
+    });
+
+    describe('an included range containing mismatched positions', () => {
+      it('parses the text within the range', () => {
+        const sourceCode = "<div>test</div>{_ignore_this_part_}";
+
+        parser.setLanguage(HTML);
+
+        const endIndex = sourceCode.indexOf('{_ignore_this_part_');
+
+        const rangeToParse = {
+          startIndex: 0,
+          startPosition: { row: 10, column: 12 },
+          endIndex,
+          endPosition: { row: 10, column: 12 + endIndex },
+        };
+
+        const htmlTree = parser.parse(sourceCode, null, { includedRanges: [rangeToParse] });
+
+        assert.deepEqual(htmlTree.getIncludedRanges()[0], rangeToParse);
+
+        assert.equal(
+          htmlTree.rootNode.toString(),
+          "(fragment (element (start_tag (tag_name)) (text) (end_tag (tag_name))))"
+        );
+      });
+    });
+
+    describe('parsing error in invalid included ranges', () => {
+      it('throws an exception', () => {
+        const ranges = [
+          { startIndex: 23, endIndex: 29, startPosition: { row: 0, column: 23 }, endPosition: { row: 0, column: 29 } },
+          { startIndex: 0, endIndex: 5, startPosition: { row: 0, column: 0 }, endPosition: { row: 0, column: 5 } },
+          { startIndex: 50, endIndex: 60, startPosition: { row: 0, column: 50 }, endPosition: { row: 0, column: 60 } },
+        ];
+        parser.setLanguage(JavaScript);
+        assert.throws(() => parser.parse('var a = 1;', null, { includedRanges: ranges }), /Overlapping ranges/);
+      });
+    });
+
+    describe('test parsing with external scanner that uses included range boundaries', () => {
+      it('parses the text within the range', () => {
+        const sourceCode = 'a <%= b() %> c <% d() %>';
+        const range1StartByte = sourceCode.indexOf(' b() ');
+        const range1EndByte = range1StartByte + ' b() '.length;
+        const range2StartByte = sourceCode.indexOf(' d() ');
+        const range2EndByte = range2StartByte + ' d() '.length;
+
+        parser.setLanguage(JavaScript);
+        const tree = parser.parse(sourceCode, null, {
+          includedRanges: [
+            {
+              startIndex: range1StartByte,
+              endIndex: range1EndByte,
+              startPosition: { row: 0, column: range1StartByte },
+              endPosition: { row: 0, column: range1EndByte }
+            },
+            {
+              startIndex: range2StartByte,
+              endIndex: range2EndByte,
+              startPosition: { row: 0, column: range2StartByte },
+              endPosition: { row: 0, column: range2EndByte }
+            },
+          ]
+        });
+
+        const root = tree.rootNode;
+        const statement1 = root.firstChild;
+        const statement2 = root.child(1);
+
+        assert.equal(
+          root.toString(),
+            "(program" +
+            " (expression_statement (call_expression function: (identifier) arguments: (arguments)))" +
+            " (expression_statement (call_expression function: (identifier) arguments: (arguments))))"
+        );
+
+        assert.equal(statement1.startIndex, sourceCode.indexOf("b()"));
+        assert.equal(statement1.endIndex, sourceCode.indexOf(" %> c"));
+        assert.equal(statement2.startIndex, sourceCode.indexOf("d()"));
+        assert.equal(statement2.endIndex, sourceCode.length - " %>".length);
+      });
+    });
+
+    describe('parsing with a newly excluded range', () => {
+      it('parses code after an edit', () => {
+        let sourceCode = '<div><span><%= something %></span></div>';
+
+        parser.setLanguage(HTML);
+        let firstTree = parser.parse(sourceCode);
+
+        // Insert code at the beginning of the document.
+        const prefix = 'a very very long line of plain text. ';
+        firstTree.edit({
+          startIndex: 0,
+          oldEndIndex: 0,
+          newEndIndex: prefix.length,
+          startPosition: { row: 0, column: 0 },
+          oldEndPosition: { row: 0, column: 0 },
+          newEndPosition: { row: 0, column: prefix.length },
+        });
+        sourceCode = prefix + sourceCode;
+
+        // Parse the HTML again, this time *excluding* the template directive
+        // (which has moved since the previous parse).
+        const directiveStart = sourceCode.indexOf('<%=');
+        const directiveEnd = sourceCode.indexOf('</span>');
+        const sourceCodeEnd = sourceCode.length;
+        const tree = parser.parse(sourceCode, firstTree, {
+          includedRanges: [
+            {
+              startIndex: 0,
+              endIndex: directiveStart,
+              startPosition: { row: 0, column: 0 },
+              endPosition: { row: 0, column: directiveStart },
+            },
+            {
+              startIndex: directiveEnd,
+              endIndex: sourceCodeEnd,
+              startPosition: { row: 0, column: directiveEnd },
+              endPosition: { row: 0, column: sourceCodeEnd },
+            },
+          ]
+        });
+
+        assert.equal(
+          tree.rootNode.toString(),
+          "(fragment (text) (element" +
+          " (start_tag (tag_name))" +
+          " (element (start_tag (tag_name)) (end_tag (tag_name)))" +
+          " (end_tag (tag_name))))"
+        );
+
+        assert.deepEqual(
+          tree.getChangedRanges(firstTree),
+          [
+            // The first range that has changed syntax is the range of the newly-inserted text.
+            {
+              startIndex: 0,
+              endIndex: prefix.length,
+              startPosition: { row: 0, column: 0 },
+              endPosition: { row: 0, column: prefix.length },
+            },
+            // Even though no edits were applied to the outer `div` element,
+            // its contents have changed syntax because a range of text that
+            // was previously included is now excluded.
+            {
+              startIndex: directiveStart,
+              endIndex: directiveEnd,
+              startPosition: { row: 0, column: directiveStart },
+              endPosition: { row: 0, column: directiveEnd },
+            },
+          ]
+        );
+      });
+    });
+
+    describe('parsing with a newly included range', () => {
+      function simpleRange(startIndex, endIndex) {
+        return {
+          startIndex,
+          endIndex,
+          startPosition: { row: 0, column: startIndex },
+          endPosition: { row: 0, column: endIndex },
+        };
+      }
+
+      it('parses code after an edit', () => {
+        const sourceCode = '<div><%= foo() %></div><span><%= bar() %></span><%= baz() %>';
+        const range1Start = sourceCode.indexOf(' foo');
+        const range2Start = sourceCode.indexOf(' bar');
+        const range3Start = sourceCode.indexOf(' baz');
+        const range1End = range1Start + 7;
+        const range2End = range2Start + 7;
+        const range3End = range3Start + 7;
+
+        // Parse only the first code directive as JavaScript
+        parser.setLanguage(JavaScript);
+        const tree = parser.parse(sourceCode, null, {
+          includedRanges: [simpleRange(range1Start, range1End)]
+        });
+        assert.equal(
+          tree.rootNode.toString(),
+          "(program" +
+          " (expression_statement (call_expression function: (identifier) arguments: (arguments))))"
+        );
+
+        // Parse both the first and third code directives as JavaScript, using the old tree as a
+        // reference.
+        const tree2 = parser.parse(sourceCode, tree, {
+          includedRanges: [
+            simpleRange(range1Start, range1End),
+            simpleRange(range3Start, range3End)
+          ]
+        });
+        assert.equal(
+          tree2.rootNode.toString(),
+          "(program" +
+          " (expression_statement (call_expression function: (identifier) arguments: (arguments)))" +
+          " (expression_statement (call_expression function: (identifier) arguments: (arguments))))"
+        );
+        assert.deepEqual(
+          tree2.getChangedRanges(tree),
+          [simpleRange(range1End, range3End)]
+        );
+
+        const tree3 = parser.parse(sourceCode, tree, {
+          includedRanges: [
+            simpleRange(range1Start, range1End),
+            simpleRange(range2Start, range2End),
+            simpleRange(range3Start, range3End),
+          ]
+        });
+        assert.equal(
+          tree3.rootNode.toString(),
+          "(program" +
+          " (expression_statement (call_expression function: (identifier) arguments: (arguments)))" +
+          " (expression_statement (call_expression function: (identifier) arguments: (arguments)))" +
+          " (expression_statement (call_expression function: (identifier) arguments: (arguments))))"
+        );
+        assert.deepEqual(
+          tree3.getChangedRanges(tree2),
+          [simpleRange(range2Start + 1, range2End - 1)]
+        );
+      });
+    });
   });
 });

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -1,6 +1,12 @@
 const fs = require("fs");
 const Parser = require("..");
+const C = require("tree-sitter-c");
+const Java = require("tree-sitter-java");
 const JavaScript = require("tree-sitter-javascript");
+const JSON = require("tree-sitter-json");
+const Python = require("tree-sitter-python");
+const Ruby = require("tree-sitter-ruby");
+const Rust = require("tree-sitter-rust");
 const { assert } = require("chai");
 const {Query, QueryCursor} = Parser
 
@@ -45,8 +51,7 @@ describe("Query", () => {
       const query = new Query(JavaScript, "(identifier) @element");
       const matches = query.matches(
         tree.rootNode,
-        { row: 1, column: 1 },
-        { row: 3, column: 1 }
+        { startPosition: { row: 1, column: 1 }, endPosition: { row: 3, column: 1 } },
       );
       assert.deepEqual(formatMatches(tree, matches), [
         { pattern: 0, captures: [{ name: "element", text: "d" }] },
@@ -192,6 +197,747 @@ describe("Query", () => {
           refutedProperties: { bar: "baz" },
         },
       ]);
+    });
+  });
+
+  describe("match limit", () => {
+    it("has too many permutations to track", () => {
+      const query = new Query(JavaScript, `
+        (array (identifier) @pre (identifier) @post)
+      `);
+
+      const source = "[" + "hello, ".repeat(50) + "];";
+
+      const tree = parser.parse(source);
+      const matches = query.matches(tree.rootNode, { matchLimit: 32 });
+
+      // For this pathological query, some match permutations will be dropped.
+      // Just check that a subset of the results are returned, and crash or
+      // leak occurs.
+      assert.deepEqual(
+        formatMatches(tree, matches)[0],
+        { pattern: 0, captures: [{ name: "pre", text: "hello" }, { name: "post", text: "hello" }] },
+      )
+      assert.equal(query.matchLimit, 32);
+      assert.equal(query.didExceedMatchLimit(), true);
+    });
+
+    it("has alternatives", () => {
+      const query = new Query(JavaScript, `
+        (
+          (comment) @doc
+          ; not immediate
+          (class_declaration) @class
+        )
+
+        (call_expression
+          function: [
+              (identifier) @function
+              (member_expression property: (property_identifier) @method)
+          ]
+        )
+      `);
+
+      const source = '/* hi */ a.b(); '.repeat(50);
+
+      const tree = parser.parse(source);
+      const matches = query.matches(tree.rootNode, { matchLimit: 32 });
+
+      assert.deepEqual(
+        formatMatches(tree, matches),
+        Array(50).fill({ pattern: 1, captures: [{ name: "method", text: "b" }] }),
+      );
+      assert.equal(query.matchLimit, 32);
+      assert.equal(query.didExceedMatchLimit(), true);
+    });
+  });
+
+  describe(".disableCapture", () =>  {
+    it("disables a capture", () => {
+      const query = new Query(JavaScript, `
+        (function_declaration
+          (identifier) @name1 @name2 @name3
+          (statement_block) @body1 @body2)
+      `);
+
+      const source = "function foo() { return 1; }";
+      const tree = parser.parse(source);
+
+      let matches = query.matches(tree.rootNode);
+      assert.deepEqual(formatMatches(tree, matches), [
+        {
+          pattern: 0,
+          captures: [
+            { name: "name1", text: "foo" },
+            { name: "name2", text: "foo" },
+            { name: "name3", text: "foo" },
+            { name: "body1", text: "{ return 1; }" },
+            { name: "body2", text: "{ return 1; }" },
+          ],
+        },
+      ]);
+
+      // disabling captures still works when there are multiple captures on a
+      // single node.
+      query.disableCapture("name2");
+      matches = query.matches(tree.rootNode);
+      assert.deepEqual(formatMatches(tree, matches), [
+        {
+          pattern: 0,
+          captures: [
+            { name: "name1", text: "foo" },
+            { name: "name3", text: "foo" },
+            { name: "body1", text: "{ return 1; }" },
+            { name: "body2", text: "{ return 1; }" },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe(".disablePattern", () =>  {
+    it("disables a pattern", () => {
+      const query = new Query(JavaScript, `
+        (function_declaration
+          name: (identifier) @name)
+        (function_declaration
+          body: (statement_block) @body)
+        (class_declaration
+          name: (identifier) @name)
+        (class_declaration
+          body: (class_body) @body)
+      `);
+
+      // disable the patterns that match names
+      query.disablePattern(0);
+      query.disablePattern(2);
+
+      const source = "class A { constructor() {} } function b() { return 1; }";
+      const tree = parser.parse(source);
+
+      const matches = query.matches(tree.rootNode);
+
+      assert.deepEqual(formatMatches(tree, matches), [
+        {
+          pattern: 3,
+          captures: [
+            { name: "body", text: "{ constructor() {} }" },
+          ],
+        },
+        {
+          pattern: 1,
+          captures: [
+            { name: "body", text: "{ return 1; }" },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe(".startIndexForPattern", () => {
+    it("returns the index where the given pattern starts in the query's source", () => {
+      const patterns1 = `
+        "+" @operator
+        "-" @operator
+        "*" @operator
+        "=" @operator
+        "=>" @operator
+      `.trimStart();
+
+      const patterns2 = `
+        (identifier) @a
+        (string) @b
+      `.trimStart();
+
+      const patterns3 = `
+        ((identifier) @b (#match? @b i))
+        (function_declaration name: (identifier) @c)
+        (method_definition name: (property_identifier) @d)
+      `.trimStart();
+
+      const source = patterns1 + patterns2 + patterns3;
+
+      const query = new Query(JavaScript, source);
+
+      assert.equal(query.startIndexForPattern(0), 0);
+      assert.equal(query.startIndexForPattern(5), patterns1.length);
+      assert.equal(query.startIndexForPattern(7), patterns1.length + patterns2.length);
+    });
+  });
+
+  describe(".isPatternGuaranteedAtStep", () => {
+    it("returns true if the given pattern is guaranteed to match at the given step", () => {
+      const rows = [
+        {
+            description: "no guaranteed steps",
+            language: Python,
+            pattern: `(expression_statement (string))`,
+            resultsBySubstring: [["expression_statement", false], ["string", false]],
+        },
+        {
+            description: "all guaranteed steps",
+            language: JavaScript,
+            pattern: `(object "{" "}")`,
+            resultsBySubstring: [["object", false], ["{", true], ["}", true]],
+        },
+        {
+            description: "a fallible step that is optional",
+            language: JavaScript,
+            pattern: `(object "{" (identifier)? @foo "}")`,
+            resultsBySubstring: [
+                ["object", false],
+                ["{", true],
+                ["(identifier)?", false],
+                ["}", true],
+            ],
+        },
+        {
+            description: "multiple fallible steps that are optional",
+            language: JavaScript,
+            pattern: `(object "{" (identifier)? @id1 ("," (identifier) @id2)? "}")`,
+            resultsBySubstring: [
+                ["object", false],
+                ["{", true],
+                ["(identifier)? @id1", false],
+                ["\",\"", false],
+                ["}", true],
+            ],
+        },
+        {
+            description: "guaranteed step after fallibe step",
+            language: JavaScript,
+            pattern: `(pair (property_identifier) ":")`,
+            resultsBySubstring: [["pair", false], ["property_identifier", false], [":", true]],
+        },
+        {
+            description: "fallible step in between two guaranteed steps",
+            language: JavaScript,
+            pattern: `(ternary_expression
+                condition: (_)
+                "?"
+                consequence: (call_expression)
+                ":"
+                alternative: (_))`,
+            resultsBySubstring: [
+                ["condition:", false],
+                ["\"?\"", false],
+                ["consequence:", false],
+                ["\":\"", true],
+                ["alternative:", true],
+            ],
+        },
+        {
+            description: "one guaranteed step after a repetition",
+            language: JavaScript,
+            pattern: `(object "{" (_) "}")`,
+            resultsBySubstring: [["object", false], ["{", false], ["(_)", false], ["}", true]],
+        },
+        {
+            description: "guaranteed steps after multiple repetitions",
+            language: JSON,
+            pattern: `(object "{" (pair) "," (pair) "," (_) "}")`,
+            resultsBySubstring: [
+                ["object", false],
+                ["{", false],
+                ["(pair) \",\" (pair)", false],
+                ["(pair) \",\" (_)", false],
+                ["\",\" (_)", false],
+                ["(_)", true],
+                ["}", true],
+            ],
+        },
+        {
+            description: "a guaranteed step with a field",
+            language: JavaScript,
+            pattern: `(binary_expression left: (expression) right: (_))`,
+            resultsBySubstring: [
+                ["binary_expression", false],
+                ["(expression)", false],
+                ["(_)", true],
+            ],
+        },
+        {
+            description: "multiple guaranteed steps with fields",
+            language: JavaScript,
+            pattern: `(function_declaration name: (identifier) body: (statement_block))`,
+            resultsBySubstring: [
+                ["function_declaration", false],
+                ["identifier", true],
+                ["statement_block", true],
+            ],
+        },
+        {
+            description: "nesting, one guaranteed step",
+            language: JavaScript,
+            pattern: `
+                (function_declaration
+                    name: (identifier)
+                    body: (statement_block "{" (expression_statement) "}"))`,
+            resultsBySubstring: [
+                ["function_declaration", false],
+                ["identifier", false],
+                ["statement_block", false],
+                ["{", false],
+                ["expression_statement", false],
+                ["}", true],
+            ],
+        },
+        {
+            description: "a guaranteed step after some deeply nested hidden nodes",
+            language: Ruby,
+            pattern: `
+            (singleton_class
+                value: (constant)
+                "end")
+            `,
+            resultsBySubstring: [
+                ["singleton_class", false],
+                ["constant", false],
+                ["end", true],
+            ],
+        },
+        {
+            description: "nesting, no guaranteed steps",
+            language: JavaScript,
+            pattern: `
+            (call_expression
+                function: (member_expression
+                  property: (property_identifier) @template-tag)
+                arguments: (template_string)) @template-call
+            `,
+            resultsBySubstring: [["property_identifier", false], ["template_string", false]],
+        },
+        {
+            description: "a guaranteed step after a nested node",
+            language: JavaScript,
+            pattern: `
+            (subscript_expression
+                object: (member_expression
+                    object: (identifier) @obj
+                    property: (property_identifier) @prop)
+                "[")
+            `,
+            resultsBySubstring: [
+                ["identifier", false],
+                ["property_identifier", false],
+                ["[", true],
+            ],
+        },
+        {
+            description: "a step that is fallible due to a predicate",
+            language: JavaScript,
+            pattern: `
+            (subscript_expression
+                object: (member_expression
+                    object: (identifier) @obj
+                    property: (property_identifier) @prop)
+                "["
+                (#match? @prop "foo"))
+            `,
+            resultsBySubstring: [
+                ["identifier", false],
+                ["property_identifier", false],
+                ["[", true],
+            ],
+        },
+        {
+            description: "alternation where one branch has guaranteed steps",
+            language: JavaScript,
+            pattern: `
+            [
+                (unary_expression (identifier))
+                (call_expression
+                  function: (_)
+                  arguments: (_))
+                (binary_expression right:(call_expression))
+            ]
+           `,
+            resultsBySubstring: [
+                ["identifier", false],
+                ["right:", false],
+                ["function:", true],
+                ["arguments:", true],
+            ],
+        },
+        {
+            description: "guaranteed step at the end of an aliased parent node",
+            language: Ruby,
+            pattern: `
+            (method_parameters "(" (identifier) @id")")
+            `,
+            resultsBySubstring: [["\"(\"", false], ["(identifier)", false], ["\")\"", true]],
+        },
+        {
+            description: "long, but not too long to analyze",
+            language: JavaScript,
+            pattern: `
+            (object "{" (pair) (pair) (pair) (pair) "}")
+            `,
+            resultsBySubstring: [
+                ["\"{\"", false],
+                ["(pair)", false],
+                ["(pair) \"}\"", false],
+                ["\"}\"", true],
+            ],
+        },
+        {
+            description: "too long to analyze",
+            language: JavaScript,
+            pattern: `
+            (object "{" (pair) (pair) (pair) (pair) (pair) (pair) (pair) (pair) (pair) (pair) (pair) (pair) "}")
+            `,
+            resultsBySubstring: [
+                ["\"{\"", false],
+                ["(pair)", false],
+                ["(pair) \"}\"", false],
+                ["\"}\"", false],
+            ],
+        },
+        {
+            description: "hidden nodes that have several fields",
+            language: Java,
+            pattern: `
+            (method_declaration name: (identifier))
+            `,
+            resultsBySubstring: [["name:", true]],
+        },
+        {
+            description: "top-level non-terminal extra nodes",
+            language: Ruby,
+            pattern: `
+            (heredoc_body
+                (interpolation)
+                (heredoc_end) @end)
+            `,
+            resultsBySubstring: [
+                ["(heredoc_body", false],
+                ["(interpolation)", false],
+                ["(heredoc_end)", true],
+            ],
+        },
+        {
+            description: "multiple extra nodes",
+            language: Rust,
+            pattern: `
+            (call_expression
+                (line_comment) @a
+                (line_comment) @b
+                (arguments))
+            `,
+            resultsBySubstring: [
+                ["(line_comment) @a", false],
+                ["(line_comment) @b", false],
+                ["(arguments)", true],
+            ],
+        },
+      ];
+
+      for (const row of rows) {
+        const query = new Query(row.language, row.pattern);
+        for (const [substring, isDefinite] of row.resultsBySubstring) {
+          const offset = row.pattern.indexOf(substring);
+          assert.equal(
+            query.isPatternGuaranteedAtStep(offset),
+            isDefinite,
+            `Description: ${row.description}, Pattern: ${row.pattern}, Substring: ${substring}, expected isDefinite to be: ${isDefinite}`,
+          );
+        }
+      }
+    });
+  });
+
+  describe(".isPatternRooted", () => {
+    it("returns true if the given pattern has a single root node", () => {
+      const rows = [
+        {
+          description: "simple token",
+          pattern: "(identifier)",
+          isRooted: true,
+        },
+        {
+          description: "simple non-terminal",
+          pattern: "(function_definition name: (identifier))",
+          isRooted: true,
+        },
+        {
+          description: "alternative of many tokens",
+          pattern: '["if" "def" (identifier) (comment)]',
+          isRooted: true,
+        },
+        {
+          description: "alternative of many non-terminals",
+          pattern: `
+            [
+              (function_definition name: (identifier))
+              (class_definition name: (identifier))
+              (block)
+            ]
+          `,
+          isRooted: true,
+        },
+        {
+          description: "two siblings",
+          pattern: '("{" "}")',
+          isRooted: false,
+        },
+        {
+          description: "top-level repetition",
+          pattern: "(comment)*",
+          isRooted: false,
+        },
+        {
+          description: "alternative where one option has two siblings",
+          pattern: `
+            [
+              (block)
+              (class_definition)
+              ("(" ")")
+              (function_definition)
+            ]
+          `,
+          isRooted: false,
+        },
+        {
+          description: "alternative where one option has a top-level repetition",
+          pattern: `
+            [
+              (block)
+              (class_definition)
+              (comment)*
+              (function_definition)
+            ]
+          `,
+          isRooted: false,
+        },
+      ];
+
+      parser.setLanguage(Python);
+      for (const row of rows) {
+        const query = new Query(Python, row.pattern);
+        assert.equal(
+          query.isPatternRooted(0),
+          row.isRooted,
+          `Description: ${row.description}, Pattern: ${row.pattern}`,
+        );
+      }
+    });
+  });
+
+  describe(".isPatternNonLocal", () => {
+    it("returns true if the given pattern has a single root node", () => {
+      const rows = [
+        {
+          description: "simple token",
+          pattern: "(identifier)",
+          language: Python,
+          isNonLocal: false,
+        },
+        {
+          description: "siblings that can occur in an argument list",
+          pattern: "((identifier) (identifier))",
+          language: Python,
+          isNonLocal: true,
+        },
+        {
+          description: "siblings that can occur in a statement block",
+          pattern: "((return_statement) (return_statement))",
+          language: Python,
+          isNonLocal: true,
+        },
+        {
+          description: "siblings that can occur in a source file",
+          pattern: "((function_definition) (class_definition))",
+          language: Python,
+          isNonLocal: true,
+        },
+        {
+          description: "siblings that can't occur in any repetition",
+          pattern: `("{" "}")`,
+          language: Python,
+          isNonLocal: false,
+        },
+        {
+          description: "siblings that can't occur in any repetition, wildcard root",
+          pattern: `(_ "{" "}") @foo`,
+          language: JavaScript,
+          isNonLocal: false,
+        },
+        {
+          description: "siblings that can occur in a class body, wildcard root",
+          pattern: "(_ (method_definition) (method_definition)) @foo",
+          language: JavaScript,
+          isNonLocal: true,
+        },
+        {
+          description: "top-level repetitions that can occur in a class body",
+          pattern: "(method_definition)+ @foo",
+          language: JavaScript,
+          isNonLocal: true,
+        },
+        {
+          description: "top-level repetitions that can occur in a statement block",
+          pattern: "(return_statement)+ @foo",
+          language: JavaScript,
+          isNonLocal: true,
+        },
+        {
+          description: "rooted pattern that can occur in a statement block",
+          pattern: "(return_statement) @foo",
+          language: JavaScript,
+          isNonLocal: false,
+        },
+      ];
+
+      for (const row of rows) {
+        const query = new Query(row.language, row.pattern);
+        assert.equal(
+          query.isPatternNonLocal(0),
+          row.isNonLocal,
+          `Description: ${row.description}, Pattern: ${row.pattern}`,
+        );
+      }
+    });
+  });
+
+  describe("max start depth", () => {
+    it("will not explore child nodes beyond the given depth", () => {
+      const source = `
+if (a1 && a2) {
+    if (b1 && b2) { }
+    if (c) { }
+}
+if (d) {
+    if (e1 && e2) { }
+    if (f) { }
+}
+`;
+
+      const rows = [
+        {
+          description: "depth 0: match translation unit",
+          depth: 0,
+          pattern: `
+              (translation_unit) @capture
+          `,
+          matches: [
+              [0, [["capture", "if (a1 && a2) {\n    if (b1 && b2) { }\n    if (c) { }\n}\nif (d) {\n    if (e1 && e2) { }\n    if (f) { }\n}\n"]]],
+          ]
+        },
+        {
+          description: "depth 0: match none",
+          depth: 0,
+          pattern: `
+              (if_statement) @capture
+          `,
+          matches: []
+        },
+        {
+          description: "depth 1: match 2 if statements at the top level",
+          depth: 1,
+          pattern: `
+              (if_statement) @capture
+          `,
+          matches: [
+              [0, [["capture", "if (a1 && a2) {\n    if (b1 && b2) { }\n    if (c) { }\n}"]]],
+              [0, [["capture", "if (d) {\n    if (e1 && e2) { }\n    if (f) { }\n}"]]],
+          ]
+        },
+        {
+          description: "depth 1 with deep pattern: match the only the first if statement",
+          depth: 1,
+          pattern: `
+              (if_statement
+                  condition: (parenthesized_expression
+                      (binary_expression)
+                  )
+              ) @capture
+          `,
+          matches: [
+              [0, [["capture", "if (a1 && a2) {\n    if (b1 && b2) { }\n    if (c) { }\n}"]]],
+          ]
+        },
+        {
+          description: "depth 3 with deep pattern: match all if statements with a binexpr condition",
+          depth: 3,
+          pattern: `
+              (if_statement
+                  condition: (parenthesized_expression
+                      (binary_expression)
+                  )
+              ) @capture
+          `,
+          matches: [
+              [0, [["capture", "if (a1 && a2) {\n    if (b1 && b2) { }\n    if (c) { }\n}"]]],
+              [0, [["capture", "if (b1 && b2) { }"]]],
+              [0, [["capture", "if (e1 && e2) { }"]]],
+          ]
+        },
+      ];
+
+      parser.setLanguage(C);
+      const tree = parser.parse(source);
+
+      for (const row of rows) {
+        const query = new Query(C, row.pattern);
+        const matches = query.matches(tree.rootNode, { maxStartDepth: row.depth });
+        const expected = row.matches.map(([pattern, captures]) => ({
+          pattern,
+          captures: captures.map(([name, text]) => ({ name, text })),
+        }));
+        assert.deepEqual(formatMatches(tree, matches), expected, row.description);
+      }
+    });
+
+    it("tests more", () => {
+      const source = `
+{
+    { }
+    {
+        { }
+    }
+}
+`
+      const rows = [
+        {
+          depth: 0,
+          matches: [
+            [0, [["capture", "{\n    { }\n    {\n        { }\n    }\n}"]]],
+          ]
+        },
+        {
+          depth: 1,
+          matches: [
+            [0, [["capture", "{\n    { }\n    {\n        { }\n    }\n}"]]],
+            [0, [["capture", "{ }"]]],
+            [0, [["capture", "{\n        { }\n    }"]]],
+          ]
+        },
+        {
+          depth: 2,
+          matches: [
+            [0, [["capture", "{\n    { }\n    {\n        { }\n    }\n}"]]],
+            [0, [["capture", "{ }"]]],
+            [0, [["capture", "{\n        { }\n    }"]]],
+            [0, [["capture", "{ }"]]],
+          ]
+        },
+      ];
+
+      parser.setLanguage(C);
+      const tree = parser.parse(source);
+      const query = new Query(C, "(compound_statement) @capture");
+      const matches = query.matches(tree.rootNode);
+      const node =  matches[0].captures[0].node;
+      assert.equal(node.type, "compound_statement");
+
+      for (const row of rows) {
+        const matches = query.matches(node, { maxStartDepth: row.depth });
+        const expected = row.matches.map(([pattern, captures]) => ({
+          pattern,
+          captures: captures.map(([name, text]) => ({ name, text })),
+        }));
+        assert.deepEqual(formatMatches(tree, matches), expected);
+      }
     });
   });
 });

--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -1,11 +1,15 @@
 declare module "tree-sitter" {
   class Parser {
     parse(input: string | Parser.Input | Parser.InputReader, oldTree?: Parser.Tree, options?: { bufferSize?: number, includedRanges?: Parser.Range[] }): Parser.Tree;
+    getIncludedRanges(): Parser.Range[];
+    getTimeoutMicros(): number;
+    setTimeoutMicros(timeout: number): void;
     getLanguage(): any;
     setLanguage(language: any): void;
     getLogger(): Parser.Logger;
     setLogger(logFunc: Parser.Logger): void;
-    printDotGraphs(enabled: boolean): void;
+    printDotGraphs(enabled: boolean, fd?: number): void;
+    reset(): void;
   }
 
   namespace Parser {
@@ -47,8 +51,11 @@ declare module "tree-sitter" {
 
     export interface SyntaxNode {
       tree: Tree;
+      id: number;
+      typeId: number;
+      grammarId: number;
       type: string;
-      typeId: string;
+      grammarName: string;
       isNamed: boolean;
       text: string;
       startPosition: Point;
@@ -68,13 +75,23 @@ declare module "tree-sitter" {
       nextNamedSibling: SyntaxNode | null;
       previousSibling: SyntaxNode | null;
       previousNamedSibling: SyntaxNode | null;
+      parseState: number;
+      nextParseState: number;
+      descendantCount: number;
 
       hasChanges(): boolean;
       hasError(): boolean;
       isMissing(): boolean;
+      isExtra(): boolean;
+      isError(): boolean;
       toString(): string;
       child(index: number): SyntaxNode | null;
       namedChild(index: number): SyntaxNode | null;
+      childForFieldName(fieldName: string): SyntaxNode | null;
+      childForFieldId(fieldId: number): SyntaxNode | null;
+      fieldNameForChild(childIndex: number): string | null;
+      childrenForFieldName(fieldName: string): Array<SyntaxNode>;
+      childrenForFieldId(fieldId: number): Array<SyntaxNode>;
       firstChildForIndex(index: number): SyntaxNode | null;
       firstNamedChildForIndex(index: number): SyntaxNode | null;
 
@@ -103,22 +120,32 @@ declare module "tree-sitter" {
       endIndex: number;
       readonly currentNode: SyntaxNode;
       readonly currentFieldName: string;
+      readonly currentFieldId: number;
+      readonly currentDepth: number;
+      readonly currentDescendantIndex: number;
 
       reset(node: SyntaxNode): void
+      resetTo(other: TreeCursor): void;
       gotoParent(): boolean;
       gotoFirstChild(): boolean;
-      gotoFirstChildForIndex(index: number): boolean;
+      gotoLastChild(): boolean;
+      gotoFirstChildForIndex(goalIndex: number): boolean;
+      gotoFirstChildForPosition(goalPosition: Point): boolean;
       gotoNextSibling(): boolean;
+      gotoPreviousSibling(): boolean;
+      gotoDescendant(goalDescendantIndex: number): boolean;
     }
 
     export interface Tree {
       readonly rootNode: SyntaxNode;
 
+      rootNodeWithOffset(offsetBytes: number, offsetExtent: Point): SyntaxNode;
       edit(delta: Edit): Tree;
       walk(): TreeCursor;
       getChangedRanges(other: Tree): Range[];
+      getIncludedRanges(): Range[];
       getEditedRange(other: Tree): Range;
-      printDotGraph(): void;
+      printDotGraph(fd?: number): void;
     }
 
     export interface QueryMatch {
@@ -140,11 +167,52 @@ declare module "tree-sitter" {
       readonly setProperties: any[];
       readonly assertedProperties: any[];
       readonly refutedProperties: any[];
+      readonly matchLimit: number;
 
-      constructor(language: any, source: string | Buffer);
+      constructor(
+        language: any,
+        source: string | Buffer,
+      );
 
-      matches(rootNode: SyntaxNode, startPosition?: Point, endPosition?: Point): QueryMatch[];
-      captures(rootNode: SyntaxNode, startPosition?: Point, endPosition?: Point): QueryCapture[];
+      matches(
+        rootNode: SyntaxNode,
+        options?: {
+          startPosition?: Point;
+          endPosition?: Point;
+          startIndex?: number;
+          endIndex?: number;
+          matchLimit?: number;
+          maxStartDepth?: number;
+        }
+      ): QueryMatch[];
+      captures(
+        rootNode: SyntaxNode,
+        options?: {
+          startPosition?: Point;
+          endPosition?: Point;
+          startIndex?: number;
+          endIndex?: number;
+          matchLimit?: number;
+          maxStartDepth?: number;
+        }
+      ): QueryCapture[];
+      disableCapture(captureName: string): void;
+      disablePattern(patternIndex: number): void;
+      isPatternGuaranteedAtStep(byteOffset: number): boolean;
+      isPatternRooted(patternIndex: number): boolean;
+      isPatternNonLocal(patternIndex: number): boolean;
+      startIndexForPattern(patternIndex: number): number;
+      didExceedMatchLimit(): boolean;
+    }
+
+    export class LookaheadIterator {
+      readonly currentSymbol: number;
+      readonly currentSymbolName: string;
+
+      reset(language: any, state: number): boolean;
+      resetState(state: number): boolean;
+      next(): number;
+      iterNames(): string[];
     }
   }
 


### PR DESCRIPTION
Similar to py-tree-sitter's updates, not done yet but putting it up for early bird reviewers:

Todo: 
- [ ] Complete dsl/index definitions
- [ ] Lookahead Iterator
- [ ] Tests for it all

@verhovsky you might be interested