### PR TITLE
Remove prebuild commands from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",
     "build": "node-gyp build",
-    "prebuild": "prebuild -t 10.0.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 -t 18.0.0 -t 20.0.0 --strip && prebuild -r electron -t 3.0.0 -t 4.0.0 -t 5.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0 -t 23.0.0 -t 24.0.0 -t 25.0.0 --strip",
-    "prebuild:upload": "prebuild --upload-all",
     "test": "mocha && jest"
   }
 }


### PR DESCRIPTION
npm has a "pre- and post- convention" for `scripts`

https://docs.npmjs.com/cli/v10/using-npm/scripts#pre--post-scripts

So this "`prebuild`" command is running every time you run `npm run build` (which happens if you have to compile the library yourself) and it's taking forever doing something useless.