### PR TITLE
fix: install only `include/tree_sitter/api.h` file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,7 @@ prebuilds
 
 vendor/tree-sitter/**/*
 !vendor/tree-sitter/lib/src/**/*.{c,h}
-!vendor/tree-sitter/lib/include/tree_sitter/*.h
+!vendor/tree-sitter/lib/include/tree_sitter/api.h
 
 .github/
 .vscode/


### PR DESCRIPTION
This PR fixes the issue https://github.com/tree-sitter/tree-sitter/issues/2677 for the NPM package.