### PR TITLE
update for v8 memory cage in node-electron V21

### DIFF
--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -27,13 +27,9 @@ void InitConversions(Local<Object> exports) {
   end_index_key.Reset(Nan::Persistent<String>(Nan::New("endIndex").ToLocalChecked()));
   end_position_key.Reset(Nan::Persistent<String>(Nan::New("endPosition").ToLocalChecked()));
 
-  point_transfer_buffer = static_cast<uint32_t *>(malloc(2 * sizeof(uint32_t)));
-
   #if defined(_MSC_VER) && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
-    auto nodeBuffer = node::Buffer::New(Isolate::GetCurrent(), (char *)point_transfer_buffer, 2 * sizeof(uint32_t), [](char *data, void *hint) {}, nullptr)
-      .ToLocalChecked()
-      .As<v8::TypedArray>();
-    v8::Local<v8::ArrayBuffer> js_point_transfer_buffer = nodeBuffer.As<v8::TypedArray>()->Buffer();
+    auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), 2 * sizeof(uint32_t));
+    point_transfer_buffer = (uint32_t *)(js_point_transfer_buffer->Data());
   #elif V8_MAJOR_VERSION < 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERSION < 4) || (defined(_MSC_VER) && NODE_RUNTIME_ELECTRON)
     auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), point_transfer_buffer, 2 * sizeof(uint32_t));
   #else

--- a/src/node.cc
+++ b/src/node.cc
@@ -24,17 +24,12 @@ static TSTreeCursor scratch_cursor = {nullptr, nullptr, {0, 0}};
 static inline void setup_transfer_buffer(uint32_t node_count) {
   uint32_t new_length = node_count * FIELD_COUNT_PER_NODE;
   if (new_length > transfer_buffer_length) {
-    if (transfer_buffer) {
-      free(transfer_buffer);
-    }
     transfer_buffer_length = new_length;
     transfer_buffer = static_cast<uint32_t *>(malloc(transfer_buffer_length * sizeof(uint32_t)));
 
     #if defined(_MSC_VER) && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
-      auto nodeBuffer = node::Buffer::New(Isolate::GetCurrent(), (char *)transfer_buffer, transfer_buffer_length * sizeof(uint32_t), [](char *data, void *hint) {}, nullptr)
-        .ToLocalChecked()
-        .As<v8::TypedArray>();
-      v8::Local<v8::ArrayBuffer> js_transfer_buffer = nodeBuffer.As<v8::TypedArray>()->Buffer();
+      auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer_length * sizeof(uint32_t));
+      transfer_buffer = (uint32_t *)(js_transfer_buffer->Data());
     #elif V8_MAJOR_VERSION < 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERSION < 4) || (defined(_MSC_VER) && NODE_RUNTIME_ELECTRON)
       auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer, transfer_buffer_length * sizeof(uint32_t));
     #else


### PR DESCRIPTION
Tested with vscode electron. 
To produce build for electron , I used @electron/rebuild and options below:

export npm_config_target=25.8.4 # vscode Help/About (vscode 1.83.1)
export npm_config_arch=x64 # optional
export npm_config_disturl=https://electronjs.org/headers
export npm_config_build_from_source=true
export npm_config_runtime=electron

reference: https://www.electronjs.org/blog/v8-memory-cage#i-want-to-refactor-a-node-native-module-to-support-electron-21-how-do-i-do-that