### PR TITLE
Make the module context aware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ on:
       - released
 
 env:
-  NODE_PREBUILD_CMD: npx prebuild -t 10.0.0 -t 12.0.0 -t 14.0.0 -t 16.0.0 -t 18.0.0 -t 20.0.0 --strip -u ${{ secrets.GH_TOKEN }}
-  ELECTRON_PREBUILD_CMD: npx prebuild -r electron -t 3.0.0 -t 4.0.0 -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.0 -t 18.0.0 -t 19.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0 -t 23.0.0 -t 24.0.0 -t 25.0.0 --strip -u ${{ secrets.GH_TOKEN }}
+  NODE_PREBUILD_CMD: npx prebuild -t 14.0.0 -t 16.0.0 -t 18.0.0 -t 20.0.0 --strip -u ${{ secrets.GH_TOKEN }}
+  ELECTRON_PREBUILD_CMD: npx prebuild -r electron -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.0 -t 18.0.0 -t 19.0.0 -t 20.0.0 -t 21.0.0 -t 22.0.0 -t 23.0.0 -t 24.0.0 -t 25.0.0 --strip -u ${{ secrets.GH_TOKEN }}
 
 jobs:
 
@@ -25,8 +25,6 @@ jobs:
           - macos-latest
           - ubuntu-20.04
         node:
-          - 10
-          - 12
           - 14
           - 16
           - 18

--- a/src/addon_data.h
+++ b/src/addon_data.h
@@ -15,8 +15,6 @@ public:
   }
 
   ~AddonData() {
-    std::free(point_transfer_buffer);
-    std::free(transfer_buffer);
     ts_query_cursor_delete(ts_query_cursor);
   }
 

--- a/src/addon_data.h
+++ b/src/addon_data.h
@@ -1,0 +1,61 @@
+#include <nan.h>
+#include <cstdlib>
+#include <tree_sitter/api.h>
+
+#ifndef NODE_TREE_SITTER_ADDON_DATA_H_
+#define NODE_TREE_SITTER_ADDON_DATA_H_
+
+namespace node_tree_sitter {
+
+class AddonData {
+public:
+  explicit AddonData(v8::Isolate* isolate) {
+    // Ensure this per-addon-instance data is deleted at environment cleanup.
+    node::AddEnvironmentCleanupHook(isolate, DeleteInstance, this);
+  }
+
+  ~AddonData() {
+    std::free(point_transfer_buffer);
+    std::free(transfer_buffer);
+    ts_query_cursor_delete(ts_query_cursor);
+  }
+
+  // conversions
+  Nan::Persistent<v8::String> row_key;
+  Nan::Persistent<v8::String> column_key;
+  Nan::Persistent<v8::String> start_index_key;
+  Nan::Persistent<v8::String> start_position_key;
+  Nan::Persistent<v8::String> end_index_key;
+  Nan::Persistent<v8::String> end_position_key;
+  uint32_t *point_transfer_buffer = nullptr;
+
+  // node
+  uint32_t *transfer_buffer = nullptr;
+  uint32_t transfer_buffer_length = 0;
+  Nan::Persistent<v8::Object> module_exports;
+  TSTreeCursor scratch_cursor = {nullptr, nullptr, {0, 0}};
+
+  // parser
+  Nan::Persistent<v8::Function> parser_constructor;
+
+  // query
+  TSQueryCursor *ts_query_cursor = nullptr;
+  Nan::Persistent<v8::Function> query_constructor;
+  Nan::Persistent<v8::FunctionTemplate> query_constructor_template;
+
+  // tree_cursor
+  Nan::Persistent<v8::Function> tree_cursor_constructor;
+
+  // tree
+  Nan::Persistent<v8::Function> tree_constructor;
+  Nan::Persistent<v8::FunctionTemplate> tree_constructor_template;
+
+private:
+  static void DeleteInstance(void* data) {
+    delete static_cast<AddonData*>(data);
+  }
+};
+
+}
+
+#endif  // NODE_TREE_SITTER_ADDON_DATA_H_

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1,5 +1,6 @@
 #include <node.h>
 #include <v8.h>
+#include "./addon_data.h"
 #include "./language.h"
 #include "./node.h"
 #include "./parser.h"
@@ -12,16 +13,22 @@ namespace node_tree_sitter {
 
 using namespace v8;
 
-void InitAll(Local<Object> exports, Local<Value> m_, void* v_) {
-  InitConversions(exports);
-  node_methods::Init(exports);
+void InitAll(Local<Object> exports, Local<Value> m_, Local<Context> context) {
+  Isolate* isolate = context->GetIsolate();
+
+  AddonData* data = new AddonData(isolate);
+
+  Local<External> data_ext = External::New(isolate, data);
+
+  InitConversions(exports, data_ext);
+  node_methods::Init(exports, data_ext);
   language_methods::Init(exports);
-  Parser::Init(exports);
-  Query::Init(exports);
-  Tree::Init(exports);
-  TreeCursor::Init(exports);
+  Parser::Init(exports, data_ext);
+  Query::Init(exports, data_ext);
+  Tree::Init(exports, data_ext);
+  TreeCursor::Init(exports, data_ext);
 }
 
-NODE_MODULE(tree_sitter_runtime_binding, InitAll)
+NODE_MODULE_CONTEXT_AWARE(tree_sitter_runtime_binding, InitAll)
 
 }  // namespace node_tree_sitter

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -23,7 +23,7 @@ void InitConversions(Local<Object> exports, Local<External> data_ext) {
   data->end_position_key.Reset(Nan::Persistent<String>(Nan::New("endPosition").ToLocalChecked()));
 
   auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), 2 * sizeof(uint32_t));
-  data->point_transfer_buffer = (uint32_t *)(js_point_transfer_buffer->Data());
+  data->point_transfer_buffer = (uint32_t *)(js_point_transfer_buffer->GetBackingStore()->Data());
 
   Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), Uint32Array::New(js_point_transfer_buffer, 0, 2));
 }

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -22,17 +22,8 @@ void InitConversions(Local<Object> exports, Local<External> data_ext) {
   data->end_index_key.Reset(Nan::Persistent<String>(Nan::New("endIndex").ToLocalChecked()));
   data->end_position_key.Reset(Nan::Persistent<String>(Nan::New("endPosition").ToLocalChecked()));
 
-  #if defined(_MSC_VER) && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
-    auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), 2 * sizeof(uint32_t));
-    point_transfer_buffer = (uint32_t *)(js_point_transfer_buffer->Data());
-  #elif V8_MAJOR_VERSION < 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERSION < 4) || (defined(_MSC_VER) && NODE_RUNTIME_ELECTRON)
-    point_transfer_buffer = static_cast<uint32_t *>(malloc(2 * sizeof(uint32_t)));
-    auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), point_transfer_buffer, 2 * sizeof(uint32_t));
-  #else
-    data->point_transfer_buffer = static_cast<uint32_t *>(malloc(2 * sizeof(uint32_t)));
-    auto backing_store = ArrayBuffer::NewBackingStore(data->point_transfer_buffer, 2 * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
-    auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
-  #endif
+  auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), 2 * sizeof(uint32_t));
+  data->point_transfer_buffer = (uint32_t *)(js_point_transfer_buffer->Data());
 
   Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), Uint32Array::New(js_point_transfer_buffer, 0, 2));
 }

--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -22,10 +22,10 @@ void InitConversions(Local<Object> exports, Local<External> data_ext) {
   data->end_index_key.Reset(Nan::Persistent<String>(Nan::New("endIndex").ToLocalChecked()));
   data->end_position_key.Reset(Nan::Persistent<String>(Nan::New("endPosition").ToLocalChecked()));
 
-  auto js_point_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), 2 * sizeof(uint32_t));
-  data->point_transfer_buffer = (uint32_t *)(js_point_transfer_buffer->GetBackingStore()->Data());
+  auto js_point_transfer_buffer = Nan::NewBuffer(2 * sizeof(uint32_t)).ToLocalChecked();
+  data->point_transfer_buffer = reinterpret_cast<uint32_t*>(node::Buffer::Data(js_point_transfer_buffer));
 
-  Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), Uint32Array::New(js_point_transfer_buffer, 0, 2));
+  Nan::Set(exports, Nan::New("pointTransferArray").ToLocalChecked(), Uint32Array::New(js_point_transfer_buffer.As<Uint8Array>()->Buffer(), 0, 2));
 }
 
 void TransferPoint(AddonData* data, const TSPoint &point) {

--- a/src/conversions.h
+++ b/src/conversions.h
@@ -4,22 +4,18 @@
 #include <nan.h>
 #include <v8.h>
 #include <tree_sitter/api.h>
+#include "./addon_data.h"
 
 namespace node_tree_sitter {
 
-void InitConversions(v8::Local<v8::Object> exports);
-v8::Local<v8::Object> RangeToJS(const TSRange &);
-v8::Local<v8::Object> PointToJS(const TSPoint &);
-void TransferPoint(const TSPoint &);
-v8::Local<v8::Number> ByteCountToJS(uint32_t);
-Nan::Maybe<TSPoint> PointFromJS(const v8::Local<v8::Value> &);
-Nan::Maybe<uint32_t> ByteCountFromJS(const v8::Local<v8::Value> &);
-Nan::Maybe<TSRange> RangeFromJS(const v8::Local<v8::Value> &);
-
-extern Nan::Persistent<v8::String> row_key;
-extern Nan::Persistent<v8::String> column_key;
-extern Nan::Persistent<v8::String> start_key;
-extern Nan::Persistent<v8::String> end_key;
+void InitConversions(v8::Local<v8::Object> exports, v8::Local<v8::External> data_ext);
+v8::Local<v8::Object> RangeToJS(AddonData* data, const TSRange &);
+v8::Local<v8::Object> PointToJS(AddonData* data, const TSPoint &);
+void TransferPoint(AddonData* data, const TSPoint &);
+v8::Local<v8::Number> ByteCountToJS(AddonData* data, uint32_t);
+Nan::Maybe<TSPoint> PointFromJS(AddonData* data, const v8::Local<v8::Value> &);
+Nan::Maybe<uint32_t> ByteCountFromJS(AddonData* data, const v8::Local<v8::Value> &);
+Nan::Maybe<TSRange> RangeFromJS(AddonData* data, const v8::Local<v8::Value> &);
 
 }  // namespace node_tree_sitter
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -22,7 +22,7 @@ static inline void setup_transfer_buffer(AddonData* data, uint32_t node_count) {
     data->transfer_buffer_length = new_length;
 
     auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), data->transfer_buffer_length * sizeof(uint32_t));
-    data->transfer_buffer = (uint32_t *)(js_transfer_buffer->Data());
+    data->transfer_buffer = (uint32_t *)(js_transfer_buffer->GetBackingStore()->Data());
 
     Nan::Set(
       Nan::New(data->module_exports),

--- a/src/node.cc
+++ b/src/node.cc
@@ -21,13 +21,13 @@ static inline void setup_transfer_buffer(AddonData* data, uint32_t node_count) {
   if (new_length > data->transfer_buffer_length) {
     data->transfer_buffer_length = new_length;
 
-    auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), data->transfer_buffer_length * sizeof(uint32_t));
-    data->transfer_buffer = (uint32_t *)(js_transfer_buffer->GetBackingStore()->Data());
+    auto js_transfer_buffer = Nan::NewBuffer(data->transfer_buffer_length * sizeof(uint32_t)).ToLocalChecked();
+    data->transfer_buffer = reinterpret_cast<uint32_t*>(node::Buffer::Data(js_transfer_buffer));
 
     Nan::Set(
       Nan::New(data->module_exports),
       Nan::New("nodeTransferArray").ToLocalChecked(),
-      Uint32Array::New(js_transfer_buffer, 0, data->transfer_buffer_length)
+      Uint32Array::New(js_transfer_buffer.As<Uint8Array>()->Buffer(), 0, data->transfer_buffer_length)
     );
   }
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -140,7 +140,7 @@ static void IsMissing(const Nan::FunctionCallbackInfo<Value> &info) {
 static void HasChanges(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     bool result = ts_node_has_changes(node);
     info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -150,7 +150,7 @@ static void HasChanges(const Nan::FunctionCallbackInfo<Value> &info) {
 static void HasError(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     bool result = ts_node_has_error(node);
     info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -160,7 +160,7 @@ static void HasError(const Nan::FunctionCallbackInfo<Value> &info) {
 static void FirstNamedChildForIndex(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     Nan::Maybe<uint32_t> byte = ByteCountFromJS(data, info[1]);
     if (byte.IsJust()) {
@@ -174,7 +174,7 @@ static void FirstNamedChildForIndex(const Nan::FunctionCallbackInfo<Value> &info
 static void FirstChildForIndex(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id && info.Length() > 1) {
     Nan::Maybe<uint32_t> byte = ByteCountFromJS(data, info[1]);
@@ -225,7 +225,7 @@ static void DescendantForIndex(const Nan::FunctionCallbackInfo<Value> &info) {
 static void NamedDescendantForPosition(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
     Nan::Maybe<TSPoint> maybe_min = PointFromJS(data, info[1]);
@@ -305,7 +305,7 @@ static void StartIndex(const Nan::FunctionCallbackInfo<Value> &info) {
 static void EndIndex(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
     int32_t result = ts_node_end_byte(node) / 2;
@@ -316,7 +316,7 @@ static void EndIndex(const Nan::FunctionCallbackInfo<Value> &info) {
 static void StartPosition(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
     TransferPoint(data, ts_node_start_point(node));
@@ -326,7 +326,7 @@ static void StartPosition(const Nan::FunctionCallbackInfo<Value> &info) {
 static void EndPosition(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
     TransferPoint(data, ts_node_end_point(node));
@@ -426,7 +426,7 @@ static void LastChild(const Nan::FunctionCallbackInfo<Value> &info) {
 static void LastNamedChild(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     uint32_t child_count = ts_node_named_child_count(node);
     if (child_count > 0) {
@@ -473,7 +473,7 @@ static void NextNamedSibling(const Nan::FunctionCallbackInfo<Value> &info) {
 static void PreviousSibling(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     MarshalNode(info, tree, ts_node_prev_sibling(node));
     return;
@@ -484,7 +484,7 @@ static void PreviousSibling(const Nan::FunctionCallbackInfo<Value> &info) {
 static void PreviousNamedSibling(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     MarshalNode(info, tree, ts_node_prev_named_sibling(node));
     return;
@@ -553,7 +553,7 @@ bool symbol_set_from_js(SymbolSet *symbols, const Local<Value> &value, const TSL
 static void Children(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
   if (!node.id) return;
 
   vector<TSNode> result;
@@ -571,7 +571,7 @@ static void Children(const Nan::FunctionCallbackInfo<Value> &info) {
 static void NamedChildren(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
   if (!node.id) return;
 
   vector<TSNode> result;
@@ -591,7 +591,7 @@ static void NamedChildren(const Nan::FunctionCallbackInfo<Value> &info) {
 static void DescendantsOfType(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
   if (!node.id) return;
 
   SymbolSet symbols;
@@ -658,7 +658,7 @@ static void DescendantsOfType(const Nan::FunctionCallbackInfo<Value> &info) {
 static void ChildNodesForFieldId(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
   if (!node.id) return;
 
   auto maybe_field_id = Nan::To<uint32_t>(info[1]);
@@ -685,7 +685,7 @@ static void ChildNodesForFieldId(const Nan::FunctionCallbackInfo<Value> &info) {
 static void ChildNodeForFieldId(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
     auto maybe_field_id = Nan::To<uint32_t>(info[1]);
@@ -703,7 +703,7 @@ static void ChildNodeForFieldId(const Nan::FunctionCallbackInfo<Value> &info) {
 static void Closest(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
   if (!node.id) return;
 
   SymbolSet symbols;
@@ -725,7 +725,7 @@ static void Closest(const Nan::FunctionCallbackInfo<Value> &info) {
 static void Walk(const Nan::FunctionCallbackInfo<Value> &info) {
   AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const Tree *tree = Tree::UnwrapTree(data, info[0]);
-  TSNode node = UnmarshalNode(tree);
+  TSNode node = UnmarshalNode(data, tree);
   TSTreeCursor cursor = ts_tree_cursor_new(node);
   info.GetReturnValue().Set(TreeCursor::NewInstance(data, cursor));
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -21,19 +21,8 @@ static inline void setup_transfer_buffer(AddonData* data, uint32_t node_count) {
   if (new_length > data->transfer_buffer_length) {
     data->transfer_buffer_length = new_length;
 
-    #if defined(_MSC_VER) && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
-      auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer_length * sizeof(uint32_t));
-      transfer_buffer = (uint32_t *)(js_transfer_buffer->Data());
-    #elif V8_MAJOR_VERSION < 8 || (V8_MAJOR_VERSION == 8 && V8_MINOR_VERSION < 4) || (defined(_MSC_VER) && NODE_RUNTIME_ELECTRON)
-      if (transfer_buffer) { free(transfer_buffer); }
-      transfer_buffer = static_cast<uint32_t *>(malloc(transfer_buffer_length * sizeof(uint32_t)));
-      auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer, transfer_buffer_length * sizeof(uint32_t));
-    #else
-      if (data->transfer_buffer) { free(data->transfer_buffer); }
-      data->transfer_buffer = static_cast<uint32_t *>(malloc(data->transfer_buffer_length * sizeof(uint32_t)));
-      auto backing_store = ArrayBuffer::NewBackingStore(data->transfer_buffer, data->transfer_buffer_length * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
-      auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
-    #endif
+    auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), data->transfer_buffer_length * sizeof(uint32_t));
+    data->transfer_buffer = (uint32_t *)(js_transfer_buffer->Data());
 
     Nan::Set(
       Nan::New(data->module_exports),

--- a/src/node.cc
+++ b/src/node.cc
@@ -16,15 +16,10 @@ using namespace v8;
 
 static const uint32_t FIELD_COUNT_PER_NODE = 6;
 
-static uint32_t *transfer_buffer = nullptr;
-static uint32_t transfer_buffer_length = 0;
-static Nan::Persistent<Object> module_exports;
-static TSTreeCursor scratch_cursor = {nullptr, nullptr, {0, 0}};
-
-static inline void setup_transfer_buffer(uint32_t node_count) {
+static inline void setup_transfer_buffer(AddonData* data, uint32_t node_count) {
   uint32_t new_length = node_count * FIELD_COUNT_PER_NODE;
-  if (new_length > transfer_buffer_length) {
-    transfer_buffer_length = new_length;
+  if (new_length > data->transfer_buffer_length) {
+    data->transfer_buffer_length = new_length;
 
     #if defined(_MSC_VER) && NODE_RUNTIME_ELECTRON && NODE_MODULE_VERSION >= 89
       auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer_length * sizeof(uint32_t));
@@ -34,16 +29,16 @@ static inline void setup_transfer_buffer(uint32_t node_count) {
       transfer_buffer = static_cast<uint32_t *>(malloc(transfer_buffer_length * sizeof(uint32_t)));
       auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), transfer_buffer, transfer_buffer_length * sizeof(uint32_t));
     #else
-      if (transfer_buffer) { free(transfer_buffer); }
-      transfer_buffer = static_cast<uint32_t *>(malloc(transfer_buffer_length * sizeof(uint32_t)));
-      auto backing_store = ArrayBuffer::NewBackingStore(transfer_buffer, transfer_buffer_length * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
+      if (data->transfer_buffer) { free(data->transfer_buffer); }
+      data->transfer_buffer = static_cast<uint32_t *>(malloc(data->transfer_buffer_length * sizeof(uint32_t)));
+      auto backing_store = ArrayBuffer::NewBackingStore(data->transfer_buffer, data->transfer_buffer_length * sizeof(uint32_t), BackingStore::EmptyDeleter, nullptr);
       auto js_transfer_buffer = ArrayBuffer::New(Isolate::GetCurrent(), std::move(backing_store));
     #endif
 
     Nan::Set(
-      Nan::New(module_exports),
+      Nan::New(data->module_exports),
       Nan::New("nodeTransferArray").ToLocalChecked(),
-      Uint32Array::New(js_transfer_buffer, 0, transfer_buffer_length)
+      Uint32Array::New(js_transfer_buffer, 0, data->transfer_buffer_length)
     );
   }
 }
@@ -65,9 +60,10 @@ void MarshalNode(const Nan::FunctionCallbackInfo<Value> &info, const Tree *tree,
 
 Local<Value> GetMarshalNodes(const Nan::FunctionCallbackInfo<Value> &info,
                          const Tree *tree, const TSNode *nodes, uint32_t node_count) {
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   auto result = Nan::New<Array>();
-  setup_transfer_buffer(node_count);
-  uint32_t *p = transfer_buffer;
+  setup_transfer_buffer(data, node_count);
+  uint32_t *p = data->transfer_buffer;
   for (unsigned i = 0; i < node_count; i++) {
     TSNode node = nodes[i];
     const auto &cache_entry = tree->cached_nodes_.find(node.id);
@@ -91,10 +87,11 @@ Local<Value> GetMarshalNodes(const Nan::FunctionCallbackInfo<Value> &info,
 }
 
 Local<Value> GetMarshalNode(const Nan::FunctionCallbackInfo<Value> &info, const Tree *tree, TSNode node) {
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   const auto &cache_entry = tree->cached_nodes_.find(node.id);
   if (cache_entry == tree->cached_nodes_.end()) {
-    setup_transfer_buffer(1);
-    uint32_t *p = transfer_buffer;
+    setup_transfer_buffer(data, 1);
+    uint32_t *p = data->transfer_buffer;
     MarshalNodeId(node.id, p);
     p += 2;
     *(p++) = node.context[0];
@@ -110,11 +107,11 @@ Local<Value> GetMarshalNode(const Nan::FunctionCallbackInfo<Value> &info, const 
   return Nan::Null();
 }
 
-void MarshalNullNode() {
-  memset(transfer_buffer, 0, FIELD_COUNT_PER_NODE * sizeof(transfer_buffer[0]));
+void MarshalNullNode(AddonData* data) {
+  memset(data->transfer_buffer, 0, FIELD_COUNT_PER_NODE * sizeof(data->transfer_buffer[0]));
 }
 
-TSNode UnmarshalNode(const Tree *tree) {
+TSNode UnmarshalNode(AddonData* data, const Tree *tree) {
   TSNode result = {{0, 0, 0, 0}, nullptr, nullptr};
   result.tree = tree->tree_;
   if (!result.tree) {
@@ -122,17 +119,18 @@ TSNode UnmarshalNode(const Tree *tree) {
     return result;
   }
 
-  result.id = UnmarshalNodeId(&transfer_buffer[0]);
-  result.context[0] = transfer_buffer[2];
-  result.context[1] = transfer_buffer[3];
-  result.context[2] = transfer_buffer[4];
-  result.context[3] = transfer_buffer[5];
+  result.id = UnmarshalNodeId(&data->transfer_buffer[0]);
+  result.context[0] = data->transfer_buffer[2];
+  result.context[1] = data->transfer_buffer[3];
+  result.context[2] = data->transfer_buffer[4];
+  result.context[3] = data->transfer_buffer[5];
   return result;
 }
 
 static void ToString(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     const char *string = ts_node_string(node);
     info.GetReturnValue().Set(Nan::New(string).ToLocalChecked());
@@ -141,8 +139,9 @@ static void ToString(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 static void IsMissing(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     bool result = ts_node_is_missing(node);
     info.GetReturnValue().Set(Nan::New<Boolean>(result));
@@ -150,7 +149,8 @@ static void IsMissing(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 static void HasChanges(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
   if (node.id) {
     bool result = ts_node_has_changes(node);
@@ -159,7 +159,8 @@ static void HasChanges(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 static void HasError(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
   if (node.id) {
     bool result = ts_node_has_error(node);
@@ -168,39 +169,42 @@ static void HasError(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 static void FirstNamedChildForIndex(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
   if (node.id) {
-    Nan::Maybe<uint32_t> byte = ByteCountFromJS(info[1]);
+    Nan::Maybe<uint32_t> byte = ByteCountFromJS(data, info[1]);
     if (byte.IsJust()) {
       MarshalNode(info, tree, ts_node_first_named_child_for_byte(node, byte.FromJust()));
       return;
     }
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void FirstChildForIndex(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
 
   if (node.id && info.Length() > 1) {
-    Nan::Maybe<uint32_t> byte = ByteCountFromJS(info[1]);
+    Nan::Maybe<uint32_t> byte = ByteCountFromJS(data, info[1]);
     if (byte.IsJust()) {
       MarshalNode(info, tree, ts_node_first_child_for_byte(node, byte.FromJust()));
       return;
     }
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void NamedDescendantForIndex(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
-    Nan::Maybe<uint32_t> maybe_min = ByteCountFromJS(info[1]);
-    Nan::Maybe<uint32_t> maybe_max = ByteCountFromJS(info[2]);
+    Nan::Maybe<uint32_t> maybe_min = ByteCountFromJS(data, info[1]);
+    Nan::Maybe<uint32_t> maybe_max = ByteCountFromJS(data, info[2]);
     if (maybe_min.IsJust() && maybe_max.IsJust()) {
       uint32_t min = maybe_min.FromJust();
       uint32_t max = maybe_max.FromJust();
@@ -208,16 +212,17 @@ static void NamedDescendantForIndex(const Nan::FunctionCallbackInfo<Value> &info
       return;
     }
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void DescendantForIndex(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
-    Nan::Maybe<uint32_t> maybe_min = ByteCountFromJS(info[1]);
-    Nan::Maybe<uint32_t> maybe_max = ByteCountFromJS(info[2]);
+    Nan::Maybe<uint32_t> maybe_min = ByteCountFromJS(data, info[1]);
+    Nan::Maybe<uint32_t> maybe_max = ByteCountFromJS(data, info[2]);
     if (maybe_min.IsJust() && maybe_max.IsJust()) {
       uint32_t min = maybe_min.FromJust();
       uint32_t max = maybe_max.FromJust();
@@ -225,16 +230,17 @@ static void DescendantForIndex(const Nan::FunctionCallbackInfo<Value> &info) {
       return;
     }
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void NamedDescendantForPosition(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
 
   if (node.id) {
-    Nan::Maybe<TSPoint> maybe_min = PointFromJS(info[1]);
-    Nan::Maybe<TSPoint> maybe_max = PointFromJS(info[2]);
+    Nan::Maybe<TSPoint> maybe_min = PointFromJS(data, info[1]);
+    Nan::Maybe<TSPoint> maybe_max = PointFromJS(data, info[2]);
     if (maybe_min.IsJust() && maybe_max.IsJust()) {
       TSPoint min = maybe_min.FromJust();
       TSPoint max = maybe_max.FromJust();
@@ -242,16 +248,17 @@ static void NamedDescendantForPosition(const Nan::FunctionCallbackInfo<Value> &i
       return;
     }
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void DescendantForPosition(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
-    Nan::Maybe<TSPoint> maybe_min = PointFromJS(info[1]);
-    Nan::Maybe<TSPoint> maybe_max = PointFromJS(info[2]);
+    Nan::Maybe<TSPoint> maybe_min = PointFromJS(data, info[1]);
+    Nan::Maybe<TSPoint> maybe_max = PointFromJS(data, info[2]);
     if (maybe_min.IsJust() && maybe_max.IsJust()) {
       TSPoint min = maybe_min.FromJust();
       TSPoint max = maybe_max.FromJust();
@@ -259,12 +266,13 @@ static void DescendantForPosition(const Nan::FunctionCallbackInfo<Value> &info) 
       return;
     }
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void Type(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
     const char *result = ts_node_type(node);
@@ -273,8 +281,9 @@ static void Type(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 static void TypeId(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
     TSSymbol result = ts_node_symbol(node);
@@ -283,8 +292,9 @@ static void TypeId(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 static void IsNamed(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
     bool result = ts_node_is_named(node);
@@ -293,8 +303,9 @@ static void IsNamed(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 static void StartIndex(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
     int32_t result = ts_node_start_byte(node) / 2;
@@ -303,7 +314,8 @@ static void StartIndex(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 static void EndIndex(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
 
   if (node.id) {
@@ -313,26 +325,29 @@ static void EndIndex(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 static void StartPosition(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
 
   if (node.id) {
-    TransferPoint(ts_node_start_point(node));
+    TransferPoint(data, ts_node_start_point(node));
   }
 }
 
 static void EndPosition(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
 
   if (node.id) {
-    TransferPoint(ts_node_end_point(node));
+    TransferPoint(data, ts_node_end_point(node));
   }
 }
 
 static void Child(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
     if (!info[1]->IsUint32()) {
@@ -343,12 +358,13 @@ static void Child(const Nan::FunctionCallbackInfo<Value> &info) {
     MarshalNode(info, tree, ts_node_child(node, index));
     return;
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void NamedChild(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
     if (!info[1]->IsUint32()) {
@@ -359,12 +375,13 @@ static void NamedChild(const Nan::FunctionCallbackInfo<Value> &info) {
     MarshalNode(info, tree, ts_node_named_child(node, index));
     return;
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void ChildCount(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
     info.GetReturnValue().Set(Nan::New(ts_node_child_count(node)));
@@ -372,8 +389,9 @@ static void ChildCount(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 static void NamedChildCount(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
 
   if (node.id) {
     info.GetReturnValue().Set(Nan::New(ts_node_named_child_count(node)));
@@ -381,28 +399,31 @@ static void NamedChildCount(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 static void FirstChild(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     MarshalNode(info, tree, ts_node_child(node, 0));
     return;
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void FirstNamedChild(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     MarshalNode(info, tree, ts_node_named_child(node, 0));
     return;
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void LastChild(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     uint32_t child_count = ts_node_child_count(node);
     if (child_count > 0) {
@@ -410,11 +431,12 @@ static void LastChild(const Nan::FunctionCallbackInfo<Value> &info) {
       return;
     }
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void LastNamedChild(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
   if (node.id) {
     uint32_t child_count = ts_node_named_child_count(node);
@@ -423,57 +445,62 @@ static void LastNamedChild(const Nan::FunctionCallbackInfo<Value> &info) {
       return;
     }
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void Parent(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     MarshalNode(info, tree, ts_node_parent(node));
     return;
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void NextSibling(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     MarshalNode(info, tree, ts_node_next_sibling(node));
     return;
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void NextNamedSibling(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
-  TSNode node = UnmarshalNode(tree);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
+  TSNode node = UnmarshalNode(data, tree);
   if (node.id) {
     MarshalNode(info, tree, ts_node_next_named_sibling(node));
     return;
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void PreviousSibling(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
   if (node.id) {
     MarshalNode(info, tree, ts_node_prev_sibling(node));
     return;
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void PreviousNamedSibling(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
   if (node.id) {
     MarshalNode(info, tree, ts_node_prev_named_sibling(node));
     return;
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 struct SymbolSet {
@@ -535,43 +562,46 @@ bool symbol_set_from_js(SymbolSet *symbols, const Local<Value> &value, const TSL
 }
 
 static void Children(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
   if (!node.id) return;
 
   vector<TSNode> result;
-  ts_tree_cursor_reset(&scratch_cursor, node);
-  if (ts_tree_cursor_goto_first_child(&scratch_cursor)) {
+  ts_tree_cursor_reset(&data->scratch_cursor, node);
+  if (ts_tree_cursor_goto_first_child(&data->scratch_cursor)) {
     do {
-      TSNode child = ts_tree_cursor_current_node(&scratch_cursor);
+      TSNode child = ts_tree_cursor_current_node(&data->scratch_cursor);
       result.push_back(child);
-    } while (ts_tree_cursor_goto_next_sibling(&scratch_cursor));
+    } while (ts_tree_cursor_goto_next_sibling(&data->scratch_cursor));
   }
 
   MarshalNodes(info, tree, result.data(), result.size());
 }
 
 static void NamedChildren(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
   if (!node.id) return;
 
   vector<TSNode> result;
-  ts_tree_cursor_reset(&scratch_cursor, node);
-  if (ts_tree_cursor_goto_first_child(&scratch_cursor)) {
+  ts_tree_cursor_reset(&data->scratch_cursor, node);
+  if (ts_tree_cursor_goto_first_child(&data->scratch_cursor)) {
     do {
-      TSNode child = ts_tree_cursor_current_node(&scratch_cursor);
+      TSNode child = ts_tree_cursor_current_node(&data->scratch_cursor);
       if (ts_node_is_named(child)) {
         result.push_back(child);
       }
-    } while (ts_tree_cursor_goto_next_sibling(&scratch_cursor));
+    } while (ts_tree_cursor_goto_next_sibling(&data->scratch_cursor));
   }
 
   MarshalNodes(info, tree, result.data(), result.size());
 }
 
 static void DescendantsOfType(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
   if (!node.id) return;
 
@@ -582,29 +612,29 @@ static void DescendantsOfType(const Nan::FunctionCallbackInfo<Value> &info) {
   TSPoint end_point = {UINT32_MAX, UINT32_MAX};
 
   if (info.Length() > 2 && info[2]->IsObject()) {
-    auto maybe_start_point = PointFromJS(info[2]);
+    auto maybe_start_point = PointFromJS(data, info[2]);
     if (maybe_start_point.IsNothing()) return;
     start_point = maybe_start_point.FromJust();
   }
 
   if (info.Length() > 3 && info[3]->IsObject()) {
-    auto maybe_end_point = PointFromJS(info[3]);
+    auto maybe_end_point = PointFromJS(data, info[3]);
     if (maybe_end_point.IsNothing()) return;
     end_point = maybe_end_point.FromJust();
   }
 
   vector<TSNode> found;
-  ts_tree_cursor_reset(&scratch_cursor, node);
+  ts_tree_cursor_reset(&data->scratch_cursor, node);
   auto already_visited_children = false;
   while (true) {
-    TSNode descendant = ts_tree_cursor_current_node(&scratch_cursor);
+    TSNode descendant = ts_tree_cursor_current_node(&data->scratch_cursor);
 
     if (!already_visited_children) {
       if (ts_node_end_point(descendant) <= start_point) {
-        if (ts_tree_cursor_goto_next_sibling(&scratch_cursor)) {
+        if (ts_tree_cursor_goto_next_sibling(&data->scratch_cursor)) {
           already_visited_children = false;
         } else {
-          if (!ts_tree_cursor_goto_parent(&scratch_cursor)) break;
+          if (!ts_tree_cursor_goto_parent(&data->scratch_cursor)) break;
           already_visited_children = true;
         }
         continue;
@@ -616,19 +646,19 @@ static void DescendantsOfType(const Nan::FunctionCallbackInfo<Value> &info) {
         found.push_back(descendant);
       }
 
-      if (ts_tree_cursor_goto_first_child(&scratch_cursor)) {
+      if (ts_tree_cursor_goto_first_child(&data->scratch_cursor)) {
         already_visited_children = false;
-      } else if (ts_tree_cursor_goto_next_sibling(&scratch_cursor)) {
+      } else if (ts_tree_cursor_goto_next_sibling(&data->scratch_cursor)) {
         already_visited_children = false;
       } else {
-        if (!ts_tree_cursor_goto_parent(&scratch_cursor)) break;
+        if (!ts_tree_cursor_goto_parent(&data->scratch_cursor)) break;
         already_visited_children = true;
       }
     } else {
-      if (ts_tree_cursor_goto_next_sibling(&scratch_cursor)) {
+      if (ts_tree_cursor_goto_next_sibling(&data->scratch_cursor)) {
         already_visited_children = false;
       } else {
-        if (!ts_tree_cursor_goto_parent(&scratch_cursor)) break;
+        if (!ts_tree_cursor_goto_parent(&data->scratch_cursor)) break;
       }
     }
   }
@@ -637,7 +667,8 @@ static void DescendantsOfType(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 static void ChildNodesForFieldId(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
   if (!node.id) return;
 
@@ -649,21 +680,22 @@ static void ChildNodesForFieldId(const Nan::FunctionCallbackInfo<Value> &info) {
   uint32_t field_id = maybe_field_id.FromJust();
 
   vector<TSNode> result;
-  ts_tree_cursor_reset(&scratch_cursor, node);
-  if (ts_tree_cursor_goto_first_child(&scratch_cursor)) {
+  ts_tree_cursor_reset(&data->scratch_cursor, node);
+  if (ts_tree_cursor_goto_first_child(&data->scratch_cursor)) {
     do {
-      TSNode child = ts_tree_cursor_current_node(&scratch_cursor);
-      if (ts_tree_cursor_current_field_id(&scratch_cursor) == field_id) {
+      TSNode child = ts_tree_cursor_current_node(&data->scratch_cursor);
+      if (ts_tree_cursor_current_field_id(&data->scratch_cursor) == field_id) {
         result.push_back(child);
       }
-    } while (ts_tree_cursor_goto_next_sibling(&scratch_cursor));
+    } while (ts_tree_cursor_goto_next_sibling(&data->scratch_cursor));
   }
 
   MarshalNodes(info, tree, result.data(), result.size());
 }
 
 static void ChildNodeForFieldId(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
 
   if (node.id) {
@@ -676,11 +708,12 @@ static void ChildNodeForFieldId(const Nan::FunctionCallbackInfo<Value> &info) {
     MarshalNode(info, tree, ts_node_child_by_field_id(node, field_id));
     return;
   }
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void Closest(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
   if (!node.id) return;
 
@@ -697,17 +730,20 @@ static void Closest(const Nan::FunctionCallbackInfo<Value> &info) {
     node = parent;
   }
 
-  MarshalNullNode();
+  MarshalNullNode(data);
 }
 
 static void Walk(const Nan::FunctionCallbackInfo<Value> &info) {
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   TSNode node = UnmarshalNode(tree);
   TSTreeCursor cursor = ts_tree_cursor_new(node);
-  info.GetReturnValue().Set(TreeCursor::NewInstance(cursor));
+  info.GetReturnValue().Set(TreeCursor::NewInstance(data, cursor));
 }
 
-void Init(Local<Object> exports) {
+void Init(Local<Object> exports, Local<External> data_ext) {
+  AddonData* data = reinterpret_cast<AddonData*>(data_ext->Value());
+
   Local<Object> result = Nan::New<Object>();
 
   FunctionPair methods[] = {
@@ -754,12 +790,12 @@ void Init(Local<Object> exports) {
     Nan::Set(
       result,
       Nan::New(methods[i].name).ToLocalChecked(),
-      Nan::GetFunction(Nan::New<FunctionTemplate>(methods[i].callback)).ToLocalChecked()
+      Nan::GetFunction(Nan::New<FunctionTemplate>(methods[i].callback, data_ext)).ToLocalChecked()
     );
   }
 
-  module_exports.Reset(exports);
-  setup_transfer_buffer(1);
+  data->module_exports.Reset(exports);
+  setup_transfer_buffer(data, 1);
 
   Nan::Set(exports, Nan::New("NodeMethods").ToLocalChecked(), result);
 }

--- a/src/node.h
+++ b/src/node.h
@@ -12,7 +12,7 @@ using namespace v8;
 namespace node_tree_sitter {
 namespace node_methods {
 
-void Init(v8::Local<v8::Object>);
+void Init(v8::Local<v8::Object>, v8::Local<v8::External>);
 void MarshalNode(const Nan::FunctionCallbackInfo<v8::Value> &info, const Tree *, TSNode);
 Local<Value> GetMarshalNode(const Nan::FunctionCallbackInfo<Value> &info, const Tree *tree, TSNode node);
 Local<Value> GetMarshalNodes(const Nan::FunctionCallbackInfo<Value> &info, const Tree *tree, const TSNode *nodes, uint32_t node_count);

--- a/src/node.h
+++ b/src/node.h
@@ -16,7 +16,7 @@ void Init(v8::Local<v8::Object>, v8::Local<v8::External>);
 void MarshalNode(const Nan::FunctionCallbackInfo<v8::Value> &info, const Tree *, TSNode);
 Local<Value> GetMarshalNode(const Nan::FunctionCallbackInfo<Value> &info, const Tree *tree, TSNode node);
 Local<Value> GetMarshalNodes(const Nan::FunctionCallbackInfo<Value> &info, const Tree *tree, const TSNode *nodes, uint32_t node_count);
-TSNode UnmarshalNode(const Tree *tree);
+TSNode UnmarshalNode(AddonData* data, const Tree *tree);
 
 static inline const void *UnmarshalNodeId(const uint32_t *buffer) {
   const void *result;

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -17,12 +17,11 @@ using namespace v8;
 using std::vector;
 using std::pair;
 
-Nan::Persistent<Function> Parser::constructor;
-
 class CallbackInput {
  public:
-  CallbackInput(v8::Local<v8::Function> callback, v8::Local<v8::Value> js_buffer_size)
-    : callback(callback),
+  CallbackInput(AddonData* data, v8::Local<v8::Function> callback, v8::Local<v8::Value> js_buffer_size)
+    : data(data),
+      callback(callback),
       byte_offset(0),
       partial_string_offset(0) {
     uint32_t buffer_size = Nan::To<uint32_t>(js_buffer_size).FromMaybe(0);
@@ -57,7 +56,7 @@ class CallbackInput {
     } else {
       Local<Function> callback = Nan::New(reader->callback);
       uint32_t utf16_unit = byte / 2;
-      Local<Value> argv[2] = { Nan::New<Number>(utf16_unit), PointToJS(position) };
+      Local<Value> argv[2] = { Nan::New<Number>(utf16_unit), PointToJS(reader->data, position) };
       TryCatch try_catch(Isolate::GetCurrent());
       auto maybe_result_value = Nan::Call(callback, GetGlobal(callback), 2, argv);
       if (try_catch.HasCaught()) return nullptr;
@@ -96,6 +95,7 @@ class CallbackInput {
     return (const char *)reader->buffer.data();
   }
 
+  AddonData* data;
   Nan::Persistent<v8::Function> callback;
   std::vector<uint16_t> buffer;
   size_t byte_offset;
@@ -103,8 +103,9 @@ class CallbackInput {
   size_t partial_string_offset;
 };
 
-void Parser::Init(Local<Object> exports) {
-  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+void Parser::Init(Local<Object> exports, Local<External> data_ext) {
+  AddonData* data = reinterpret_cast<AddonData*>(data_ext->Value());
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New, data_ext);
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
   Local<String> class_name = Nan::New("Parser").ToLocalChecked();
   tpl->SetClassName(class_name);
@@ -118,11 +119,11 @@ void Parser::Init(Local<Object> exports) {
   };
 
   for (size_t i = 0; i < length_of_array(methods); i++) {
-    Nan::SetPrototypeMethod(tpl, methods[i].name, methods[i].callback);
+    Nan::SetPrototypeMethod(tpl, methods[i].name, methods[i].callback, data_ext);
   }
 
-  constructor.Reset(Nan::Persistent<Function>(Nan::GetFunction(tpl).ToLocalChecked()));
-  Nan::Set(exports, class_name, Nan::New(constructor));
+  data->parser_constructor.Reset(Nan::Persistent<Function>(Nan::GetFunction(tpl).ToLocalChecked()));
+  Nan::Set(exports, class_name, Nan::New(data->parser_constructor));
   Nan::Set(exports, Nan::New("LANGUAGE_VERSION").ToLocalChecked(), Nan::New<Number>(TREE_SITTER_LANGUAGE_VERSION));
 }
 
@@ -130,7 +131,7 @@ Parser::Parser() : parser_(ts_parser_new()) {}
 
 Parser::~Parser() { ts_parser_delete(parser_); }
 
-static bool handle_included_ranges(TSParser *parser, Local<Value> arg) {
+static bool handle_included_ranges(AddonData* data, TSParser *parser, Local<Value> arg) {
   uint32_t last_included_range_end = 0;
   if (arg->IsArray()) {
     auto js_included_ranges = Local<Array>::Cast(arg);
@@ -138,7 +139,7 @@ static bool handle_included_ranges(TSParser *parser, Local<Value> arg) {
     for (unsigned i = 0; i < js_included_ranges->Length(); i++) {
       Local<Value> range_value;
       if (!Nan::Get(js_included_ranges, i).ToLocal(&range_value)) return false;
-      auto maybe_range = RangeFromJS(range_value);
+      auto maybe_range = RangeFromJS(data, range_value);
       if (!maybe_range.IsJust()) return false;
       auto range = maybe_range.FromJust();
       if (range.start_byte < last_included_range_end) {
@@ -157,13 +158,14 @@ static bool handle_included_ranges(TSParser *parser, Local<Value> arg) {
 }
 
 void Parser::New(const Nan::FunctionCallbackInfo<Value> &info) {
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   if (info.IsConstructCall()) {
     Parser *parser = new Parser();
     parser->Wrap(info.This());
     info.GetReturnValue().Set(info.This());
   } else {
     Local<Object> self;
-    MaybeLocal<Object> maybe_self = Nan::New(constructor)->NewInstance(Nan::GetCurrentContext());
+    MaybeLocal<Object> maybe_self = Nan::New(data->parser_constructor)->NewInstance(Nan::GetCurrentContext());
     if (maybe_self.ToLocal(&self)) {
       info.GetReturnValue().Set(self);
     } else {
@@ -183,6 +185,7 @@ void Parser::SetLanguage(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 void Parser::Parse(const Nan::FunctionCallbackInfo<Value> &info) {
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   Parser *parser = ObjectWrap::Unwrap<Parser>(info.This());
 
   if (!info[0]->IsFunction()) {
@@ -195,7 +198,7 @@ void Parser::Parse(const Nan::FunctionCallbackInfo<Value> &info) {
   Local<Object> js_old_tree;
   const TSTree *old_tree = nullptr;
   if (info.Length() > 1 && !info[1]->IsNull() && !info[1]->IsUndefined() && Nan::To<Object>(info[1]).ToLocal(&js_old_tree)) {
-    const Tree *tree = Tree::UnwrapTree(js_old_tree);
+    const Tree *tree = Tree::UnwrapTree(data, js_old_tree);
     if (!tree) {
       Nan::ThrowTypeError("Second argument must be a tree");
       return;
@@ -206,11 +209,11 @@ void Parser::Parse(const Nan::FunctionCallbackInfo<Value> &info) {
   Local<Value> buffer_size = Nan::Null();
   if (info.Length() > 2) buffer_size = info[2];
 
-  if (!handle_included_ranges(parser->parser_, info[3])) return;
+  if (!handle_included_ranges(data, parser->parser_, info[3])) return;
 
-  CallbackInput callback_input(callback, buffer_size);
+  CallbackInput callback_input(data, callback, buffer_size);
   TSTree *tree = ts_parser_parse(parser->parser_, old_tree, callback_input.Input());
-  Local<Value> result = Tree::NewInstance(tree);
+  Local<Value> result = Tree::NewInstance(data, tree);
   info.GetReturnValue().Set(result);
 }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -10,7 +10,7 @@ namespace node_tree_sitter {
 
 class Parser : public Nan::ObjectWrap {
  public:
-  static void Init(v8::Local<v8::Object> exports);
+  static void Init(v8::Local<v8::Object> exports, v8::Local<v8::External> data_ext);
 
   TSParser *parser_;
 
@@ -24,8 +24,6 @@ class Parser : public Nan::ObjectWrap {
   static void SetLogger(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void Parse(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void PrintDotGraphs(const Nan::FunctionCallbackInfo<v8::Value> &);
-
-  static Nan::Persistent<v8::Function> constructor;
 };
 
 }  // namespace node_tree_sitter

--- a/src/query.cc
+++ b/src/query.cc
@@ -215,7 +215,7 @@ void Query::Matches(const Nan::FunctionCallbackInfo<Value> &info) {
   }
 
   TSQuery *ts_query = query->query_;
-  TSNode rootNode = node_methods::UnmarshalNode(tree);
+  TSNode rootNode = node_methods::UnmarshalNode(data, tree);
   TSPoint start_point = {start_row, start_column};
   TSPoint end_point = {end_row, end_column};
   ts_query_cursor_set_point_range(data->ts_query_cursor, start_point, end_point);
@@ -272,7 +272,7 @@ void Query::Captures(const Nan::FunctionCallbackInfo<Value> &info) {
   }
 
   TSQuery *ts_query = query->query_;
-  TSNode rootNode = node_methods::UnmarshalNode(tree);
+  TSNode rootNode = node_methods::UnmarshalNode(data, tree);
   TSPoint start_point = {start_row, start_column};
   TSPoint end_point = {end_row, end_column};
   ts_query_cursor_set_point_range(data->ts_query_cursor, start_point, end_point);

--- a/src/query.cc
+++ b/src/query.cc
@@ -24,14 +24,11 @@ const char *query_error_names[] = {
   "TSQueryErrorStructure",
 };
 
-TSQueryCursor *Query::ts_query_cursor;
-Nan::Persistent<Function> Query::constructor;
-Nan::Persistent<FunctionTemplate> Query::constructor_template;
+void Query::Init(Local<Object> exports, Local<External> data_ext) {
+  AddonData* data = reinterpret_cast<AddonData*>(data_ext->Value());
+  data->ts_query_cursor = ts_query_cursor_new();
 
-void Query::Init(Local<Object> exports) {
-  ts_query_cursor = ts_query_cursor_new();
-
-  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New, data_ext);
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
   Local<String> class_name = Nan::New("Query").ToLocalChecked();
   tpl->SetClassName(class_name);
@@ -43,13 +40,13 @@ void Query::Init(Local<Object> exports) {
   };
 
   for (size_t i = 0; i < length_of_array(methods); i++) {
-    Nan::SetPrototypeMethod(tpl, methods[i].name, methods[i].callback);
+    Nan::SetPrototypeMethod(tpl, methods[i].name, methods[i].callback, data_ext);
   }
 
   Local<Function> ctor = Nan::GetFunction(tpl).ToLocalChecked();
 
-  constructor_template.Reset(tpl);
-  constructor.Reset(ctor);
+  data->query_constructor_template.Reset(tpl);
+  data->query_constructor.Reset(ctor);
   Nan::Set(exports, class_name, ctor);
 }
 
@@ -59,10 +56,10 @@ Query::~Query() {
   ts_query_delete(query_);
 }
 
-Local<Value> Query::NewInstance(TSQuery *query) {
+Local<Value> Query::NewInstance(AddonData* data, TSQuery *query) {
   if (query) {
     Local<Object> self;
-    MaybeLocal<Object> maybe_self = Nan::NewInstance(Nan::New(constructor));
+    MaybeLocal<Object> maybe_self = Nan::NewInstance(Nan::New(data->query_constructor));
     if (maybe_self.ToLocal(&self)) {
       (new Query(query))->Wrap(self);
       return self;
@@ -71,17 +68,18 @@ Local<Value> Query::NewInstance(TSQuery *query) {
   return Nan::Null();
 }
 
-Query *Query::UnwrapQuery(const Local<Value> &value) {
+Query *Query::UnwrapQuery(AddonData* data, const Local<Value> &value) {
   if (!value->IsObject()) return nullptr;
   Local<Object> js_query = Local<Object>::Cast(value);
-  if (!Nan::New(constructor_template)->HasInstance(js_query)) return nullptr;
+  if (!Nan::New(data->query_constructor_template)->HasInstance(js_query)) return nullptr;
   return ObjectWrap::Unwrap<Query>(js_query);
 }
 
 void Query::New(const Nan::FunctionCallbackInfo<Value> &info) {
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   if (!info.IsConstructCall()) {
     Local<Object> self;
-    MaybeLocal<Object> maybe_self = Nan::New(constructor)->NewInstance(Nan::GetCurrentContext());
+    MaybeLocal<Object> maybe_self = Nan::New(data->query_constructor)->NewInstance(Nan::GetCurrentContext());
     if (maybe_self.ToLocal(&self)) {
       info.GetReturnValue().Set(self);
     } else {
@@ -144,7 +142,8 @@ void Query::New(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 void Query::GetPredicates(const Nan::FunctionCallbackInfo<Value> &info) {
-  Query *query = Query::UnwrapQuery(info.This());
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  Query *query = Query::UnwrapQuery(data, info.This());
   auto ts_query = query->query_;
 
   auto pattern_len = ts_query_pattern_count(ts_query);
@@ -197,8 +196,9 @@ void Query::GetPredicates(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 void Query::Matches(const Nan::FunctionCallbackInfo<Value> &info) {
-  Query *query = Query::UnwrapQuery(info.This());
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  Query *query = Query::UnwrapQuery(data, info.This());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   uint32_t start_row    = Nan::To<uint32_t>(info[1]).ToChecked();
   uint32_t start_column = Nan::To<uint32_t>(info[2]).ToChecked() << 1;
   uint32_t end_row      = Nan::To<uint32_t>(info[3]).ToChecked();
@@ -218,15 +218,15 @@ void Query::Matches(const Nan::FunctionCallbackInfo<Value> &info) {
   TSNode rootNode = node_methods::UnmarshalNode(tree);
   TSPoint start_point = {start_row, start_column};
   TSPoint end_point = {end_row, end_column};
-  ts_query_cursor_set_point_range(ts_query_cursor, start_point, end_point);
-  ts_query_cursor_exec(ts_query_cursor, ts_query, rootNode);
+  ts_query_cursor_set_point_range(data->ts_query_cursor, start_point, end_point);
+  ts_query_cursor_exec(data->ts_query_cursor, ts_query, rootNode);
 
   Local<Array> js_matches = Nan::New<Array>();
   unsigned index = 0;
   vector<TSNode> nodes;
   TSQueryMatch match;
 
-  while (ts_query_cursor_next_match(ts_query_cursor, &match)) {
+  while (ts_query_cursor_next_match(data->ts_query_cursor, &match)) {
     Nan::Set(js_matches, index++, Nan::New(match.pattern_index));
 
     for (uint16_t i = 0; i < match.capture_count; i++) {
@@ -253,8 +253,9 @@ void Query::Matches(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 void Query::Captures(const Nan::FunctionCallbackInfo<Value> &info) {
-  Query *query = Query::UnwrapQuery(info.This());
-  const Tree *tree = Tree::UnwrapTree(info[0]);
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
+  Query *query = Query::UnwrapQuery(data, info.This());
+  const Tree *tree = Tree::UnwrapTree(data, info[0]);
   uint32_t start_row    = Nan::To<uint32_t>(info[1]).ToChecked();
   uint32_t start_column = Nan::To<uint32_t>(info[2]).ToChecked() << 1;
   uint32_t end_row      = Nan::To<uint32_t>(info[3]).ToChecked();
@@ -274,8 +275,8 @@ void Query::Captures(const Nan::FunctionCallbackInfo<Value> &info) {
   TSNode rootNode = node_methods::UnmarshalNode(tree);
   TSPoint start_point = {start_row, start_column};
   TSPoint end_point = {end_row, end_column};
-  ts_query_cursor_set_point_range(ts_query_cursor, start_point, end_point);
-  ts_query_cursor_exec(ts_query_cursor, ts_query, rootNode);
+  ts_query_cursor_set_point_range(data->ts_query_cursor, start_point, end_point);
+  ts_query_cursor_exec(data->ts_query_cursor, ts_query, rootNode);
 
   Local<Array> js_matches = Nan::New<Array>();
   unsigned index = 0;
@@ -284,7 +285,7 @@ void Query::Captures(const Nan::FunctionCallbackInfo<Value> &info) {
   uint32_t capture_index;
 
   while (ts_query_cursor_next_capture(
-    ts_query_cursor,
+    data->ts_query_cursor,
     &match,
     &capture_index
   )) {

--- a/src/query.h
+++ b/src/query.h
@@ -6,14 +6,15 @@
 #include <node_object_wrap.h>
 #include <unordered_map>
 #include <tree_sitter/api.h>
+#include "./addon_data.h"
 
 namespace node_tree_sitter {
 
 class Query : public Nan::ObjectWrap {
  public:
-  static void Init(v8::Local<v8::Object> exports);
-  static v8::Local<v8::Value> NewInstance(TSQuery *);
-  static Query *UnwrapQuery(const v8::Local<v8::Value> &);
+  static void Init(v8::Local<v8::Object> exports, v8::Local<v8::External> data_ext);
+  static v8::Local<v8::Value> NewInstance(AddonData* data, TSQuery *);
+  static Query *UnwrapQuery(AddonData* data, const v8::Local<v8::Value> &);
 
   TSQuery *query_;
 
@@ -25,10 +26,6 @@ class Query : public Nan::ObjectWrap {
   static void Matches(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void Captures(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void GetPredicates(const Nan::FunctionCallbackInfo<v8::Value> &);
-
-  static TSQueryCursor *ts_query_cursor;
-  static Nan::Persistent<v8::Function> constructor;
-  static Nan::Persistent<v8::FunctionTemplate> constructor_template;
 };
 
 }  // namespace node_tree_sitter

--- a/src/tree.h
+++ b/src/tree.h
@@ -6,14 +6,15 @@
 #include <node_object_wrap.h>
 #include <unordered_map>
 #include <tree_sitter/api.h>
+#include "./addon_data.h"
 
 namespace node_tree_sitter {
 
 class Tree : public Nan::ObjectWrap {
  public:
-  static void Init(v8::Local<v8::Object> exports);
-  static v8::Local<v8::Value> NewInstance(TSTree *);
-  static const Tree *UnwrapTree(const v8::Local<v8::Value> &);
+  static void Init(v8::Local<v8::Object> exports, v8::Local<v8::External> data_ext);
+  static v8::Local<v8::Value> NewInstance(AddonData* data, TSTree *);
+  static const Tree *UnwrapTree(AddonData* data, const v8::Local<v8::Value> &);
 
   struct NodeCacheEntry {
     Tree *tree;
@@ -37,8 +38,6 @@ class Tree : public Nan::ObjectWrap {
   static void CacheNode(const Nan::FunctionCallbackInfo<v8::Value> &);
   static void CacheNodes(const Nan::FunctionCallbackInfo<v8::Value> &);
 
-  static Nan::Persistent<v8::Function> constructor;
-  static Nan::Persistent<v8::FunctionTemplate> constructor_template;
 };
 
 }  // namespace node_tree_sitter

--- a/src/tree_cursor.cc
+++ b/src/tree_cursor.cc
@@ -11,10 +11,9 @@ namespace node_tree_sitter {
 
 using namespace v8;
 
-Nan::Persistent<Function> TreeCursor::constructor;
-
-void TreeCursor::Init(v8::Local<v8::Object> exports) {
-  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+void TreeCursor::Init(v8::Local<v8::Object> exports, v8::Local<v8::External> data_ext) {
+  AddonData* data = reinterpret_cast<AddonData*>(data_ext->Value());
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New, data_ext);
   Local<String> class_name = Nan::New("TreeCursor").ToLocalChecked();
   tpl->SetClassName(class_name);
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
@@ -47,17 +46,17 @@ void TreeCursor::Init(v8::Local<v8::Object> exports) {
   }
 
   for (size_t i = 0; i < length_of_array(methods); i++) {
-    Nan::SetPrototypeMethod(tpl, methods[i].name, methods[i].callback);
+    Nan::SetPrototypeMethod(tpl, methods[i].name, methods[i].callback, data_ext);
   }
 
   Local<Function> constructor_local = Nan::GetFunction(tpl).ToLocalChecked();
   Nan::Set(exports, class_name, constructor_local);
-  constructor.Reset(Nan::Persistent<Function>(constructor_local));
+  data->tree_cursor_constructor.Reset(Nan::Persistent<Function>(constructor_local));
 }
 
-Local<Value> TreeCursor::NewInstance(TSTreeCursor cursor) {
+Local<Value> TreeCursor::NewInstance(AddonData* data, TSTreeCursor cursor) {
   Local<Object> self;
-  MaybeLocal<Object> maybe_self = Nan::New(constructor)->NewInstance(Nan::GetCurrentContext());
+  MaybeLocal<Object> maybe_self = Nan::New(data->tree_cursor_constructor)->NewInstance(Nan::GetCurrentContext());
   if (maybe_self.ToLocal(&self)) {
     (new TreeCursor(cursor))->Wrap(self);
     return self;
@@ -109,29 +108,33 @@ void TreeCursor::GotoNextSibling(const Nan::FunctionCallbackInfo<Value> &info) {
 }
 
 void TreeCursor::StartPosition(const Nan::FunctionCallbackInfo<Value> &info) {
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
-  TransferPoint(ts_node_start_point(node));
+  TransferPoint(data, ts_node_start_point(node));
 }
 
 void TreeCursor::EndPosition(const Nan::FunctionCallbackInfo<Value> &info) {
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
-  TransferPoint(ts_node_end_point(node));
+  TransferPoint(data, ts_node_end_point(node));
 }
 
 void TreeCursor::CurrentNode(const Nan::FunctionCallbackInfo<Value> &info) {
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   Local<String> key = Nan::New<String>("tree").ToLocalChecked();
-  const Tree *tree = Tree::UnwrapTree(Nan::Get(info.This(), key).ToLocalChecked());
+  const Tree *tree = Tree::UnwrapTree(data, Nan::Get(info.This(), key).ToLocalChecked());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
   node_methods::MarshalNode(info, tree, node);
 }
 
 void TreeCursor::Reset(const Nan::FunctionCallbackInfo<Value> &info) {
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   Local<String> key = Nan::New<String>("tree").ToLocalChecked();
-  const Tree *tree = Tree::UnwrapTree(Nan::Get(info.This(), key).ToLocalChecked());
+  const Tree *tree = Tree::UnwrapTree(data, Nan::Get(info.This(), key).ToLocalChecked());
   TSNode node = node_methods::UnmarshalNode(tree);
   ts_tree_cursor_reset(&cursor->cursor_, node);
 }
@@ -165,15 +168,17 @@ void TreeCursor::CurrentFieldName(v8::Local<v8::String> prop, const Nan::Propert
 }
 
 void TreeCursor::StartIndex(v8::Local<v8::String> prop, const Nan::PropertyCallbackInfo<v8::Value> &info) {
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
-  info.GetReturnValue().Set(ByteCountToJS(ts_node_start_byte(node)));
+  info.GetReturnValue().Set(ByteCountToJS(data, ts_node_start_byte(node)));
 }
 
 void TreeCursor::EndIndex(v8::Local<v8::String> prop, const Nan::PropertyCallbackInfo<v8::Value> &info) {
+  AddonData* data = reinterpret_cast<AddonData*>(info.Data().As<External>()->Value());
   TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   TSNode node = ts_tree_cursor_current_node(&cursor->cursor_);
-  info.GetReturnValue().Set(ByteCountToJS(ts_node_end_byte(node)));
+  info.GetReturnValue().Set(ByteCountToJS(data, ts_node_end_byte(node)));
 }
 
 }

--- a/src/tree_cursor.cc
+++ b/src/tree_cursor.cc
@@ -135,7 +135,7 @@ void TreeCursor::Reset(const Nan::FunctionCallbackInfo<Value> &info) {
   TreeCursor *cursor = Nan::ObjectWrap::Unwrap<TreeCursor>(info.This());
   Local<String> key = Nan::New<String>("tree").ToLocalChecked();
   const Tree *tree = Tree::UnwrapTree(data, Nan::Get(info.This(), key).ToLocalChecked());
-  TSNode node = node_methods::UnmarshalNode(tree);
+  TSNode node = node_methods::UnmarshalNode(data, tree);
   ts_tree_cursor_reset(&cursor->cursor_, node);
 }
 

--- a/src/tree_cursor.h
+++ b/src/tree_cursor.h
@@ -5,13 +5,14 @@
 #include <nan.h>
 #include <node_object_wrap.h>
 #include <tree_sitter/api.h>
+#include "./addon_data.h"
 
 namespace node_tree_sitter {
 
 class TreeCursor : public Nan::ObjectWrap {
  public:
-  static void Init(v8::Local<v8::Object> exports);
-  static v8::Local<v8::Value> NewInstance(TSTreeCursor);
+  static void Init(v8::Local<v8::Object> exports, v8::Local<v8::External> data_ext);
+  static v8::Local<v8::Value> NewInstance(AddonData* data, TSTreeCursor);
 
  private:
   explicit TreeCursor(TSTreeCursor);
@@ -35,8 +36,6 @@ class TreeCursor : public Nan::ObjectWrap {
   static void EndIndex(v8::Local<v8::String>, const Nan::PropertyCallbackInfo<v8::Value> &);
 
   TSTreeCursor cursor_;
-  static Nan::Persistent<v8::Function> constructor;
-  static Nan::Persistent<v8::FunctionTemplate> constructor_template;
 };
 
 }  // namespace node_tree_sitter


### PR DESCRIPTION
This makes this binding context aware, while still using v8/NaN/Node APIs directly, by moving all global data into an object, and removing global external buffers usage, which leads to seg faults/access violations on unloading the module.

The language bindings will also need to be made context aware which is done here https://github.com/tree-sitter/tree-sitter/pull/2841, and will need to be applied to each language binding.

Dropped supported for some ancient EOL Node.js and Electron versions so we don't have to ifdef for those.

Contributed on behalf of [Swimm](https://swimm.io/)