### PR TITLE
Pin to Ubuntu 20.04 which is the actual minimum for at least Node 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         os:
           - windows-2019
           - macos-latest
-          - ubuntu-latest
+          - ubuntu-20.04
         node:
           - 10
           - 12

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
   publish:
     if: ${{ github.event_name == 'release' }}
     name: Publish to npm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: test
     steps:
       - uses: actions/checkout@v3
@@ -74,7 +74,7 @@ jobs:
         os:
           - windows-2019
           - macos-latest
-          - ubuntu-latest
+          - ubuntu-20.04
       fail-fast: false
     name: Prebuild for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Technically older Node.js versions require an even older machine to ensure compatibility, but many of those are EOL in practice...

Contributed on behalf of [Swimm](https://swimm.io/).