### PR TITLE
Fix memory leak in CallbackInput

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -24,6 +24,11 @@ class CallbackInput final {
     }
   }
 
+  ~CallbackInput() {
+    callback.Reset();
+    partial_string.Reset();
+  }
+
   TSInput Input() {
     TSInput result;
     result.payload = static_cast<void *>(this);


### PR DESCRIPTION
## Issue

I noticed there was a large buildup of memory when repeatedly calling `parse` on a `Parser`. After digging into the issue it turns out that `input`, and therefore `inputString`, was being retained by `CallbackInput` 

https://github.com/tree-sitter/node-tree-sitter/blob/419da7d40a76046d53ae1c00aeafa2e0587a3e12/index.js#L355

## Fix

This PR simply resets the resources in the destructor of `CallbackInput` to allow `input` and `inputString` to be garbage collected.