### PR TITLE
fix: compilation with clang >=18

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -121,10 +121,10 @@ TSNode UnmarshalNode(Napi::Env env, const Tree *tree) {
 }
 
 struct SymbolSet {
-  void add(TSSymbol symbol) { symbols += symbol; }
-  [[nodiscard]] bool contains(TSSymbol symbol) const { return symbols.find(symbol) != symbols.npos; }
+  void add(TSSymbol symbol) { symbols.push_back(symbol); }
+  [[nodiscard]] bool contains(TSSymbol symbol) const { return std::find(symbols.begin(), symbols.end(), symbol) != symbols.end(); }
  private:
-  std::basic_string<TSSymbol> symbols;
+  std::vector<TSSymbol> symbols;
 };
 
 void symbol_set_from_js(SymbolSet *symbols, const Napi::Value &value, const TSLanguage *language) {


### PR DESCRIPTION
LLVM >= 18 has deprecated and removed char_trait implementation for non char types in https://github.com/llvm/llvm-project/commit/c3668779c13596e223c26fbd49670d18cd638c40, for VSCode we build the native modules using libc++ and clang to align with the runtime, building current node-tree-sitter leads to the following error

```
/mnt/vss/_work/1/s/.build/libcxx_headers/include/__string/char_traits.h:617:23: error: implicit instantiation of undefined template 'std::char_traits<unsigned short>'
  617 |   const _CharT* __r = _Traits::find(__p + __pos, __sz - __pos, __c);
      |                       ^
/mnt/vss/_work/1/s/.build/libcxx_headers/include/string:3375:15: note: in instantiation of function template specialization 'std::__str_find<unsigned short, unsigned long, std::char_traits<unsigned short>, 18446744073709551615UL>' requested here
 3375 |   return std::__str_find<value_type, size_type, traits_type, npos>(data(), size(), __c, __pos);
      |               ^
../src/node.cc:484:51: note: in instantiation of member function 'std::basic_string<unsigned short>::find' requested here
  484 |   bool contains(TSSymbol symbol) { return symbols.find(symbol) != symbols.npos; }
      |                                                   ^
/mnt/vss/_work/1/s/.build/libcxx_headers/include/__fwd/string.h:23:29: note: template is declared here
   23 | struct _LIBCPP_TEMPLATE_VIS char_traits;
```