### PR TITLE
WIP: feat: Add iterator methods to Query

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,6 +12,7 @@
         "src/language.cc",
         "src/logger.cc",
         "src/lookaheaditerator.cc",
+        "src/matches_iterator.cc",
         "src/node.cc",
         "src/parser.cc",
         "src/query.cc",

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const binding = require('node-gyp-build')(__dirname);
-const {Query, Parser, NodeMethods, Tree, TreeCursor, LookaheadIterator} = binding;
+const {Query, MatchesIterator, Parser, NodeMethods, Tree, TreeCursor, LookaheadIterator} = binding;
 
 const util = require('util');
 
@@ -15,10 +15,10 @@ Object.defineProperty(Tree.prototype, 'rootNode', {
       Due to a race condition arising from Jest's worker pool, "this"
       has no knowledge of the native extension if the extension has not
       yet loaded when multiple Jest tests are being run simultaneously.
-      If the extension has correctly loaded, "this" should be an instance 
+      If the extension has correctly loaded, "this" should be an instance
       of the class whose prototype we are acting on (in this case, Tree).
-      Furthermore, the race condition sometimes results in the function in 
-      question being undefined even when the context is correct, so we also 
+      Furthermore, the race condition sometimes results in the function in
+      question being undefined even when the context is correct, so we also
       perform a null function check.
     */
     if (this instanceof Tree && rootNode) {
@@ -420,7 +420,7 @@ Object.defineProperties(TreeCursor.prototype, {
  * Query
  */
 
-const {_matches, _captures} = Query.prototype;
+const {_matches, _matchesIter, _captures} = Query.prototype;
 
 const PREDICATE_STEP_TYPE = {
   DONE: 0,
@@ -660,6 +660,25 @@ Query.prototype.matches = function(
   return results;
 }
 
+Query.prototype.matchesIter = function(
+  node,
+  {
+    startPosition = ZERO_POINT,
+    endPosition = ZERO_POINT,
+    startIndex = 0,
+    endIndex = 0,
+    matchLimit = 0xFFFFFFFF,
+    maxStartDepth = 0xFFFFFFFF
+  } = {}
+) {
+  marshalNode(node);
+  return _matchesIter.call(this, node.tree,
+    startPosition.row, startPosition.column,
+    endPosition.row, endPosition.column,
+    startIndex, endIndex, matchLimit, maxStartDepth
+  );
+}
+
 Query.prototype.captures = function(
   node,
   {
@@ -708,6 +727,49 @@ Query.prototype.captures = function(
   }
 
   return results;
+}
+
+/**
+ * MatchesIterator
+ */
+
+const { _next: _matchesNext } = MatchesIterator.prototype;
+
+MatchesIterator.prototype.next = function () {
+  while (true) {
+    const { done, value } = _matchesNext.call(this);
+    if (done) {
+      return { done };
+    }
+    const [returnedMatches, returnedNodes] = value;
+    const nodes = unmarshalNodes(returnedNodes, this.tree);
+
+    let i = 0
+    let nodeIndex = 0;
+    while (i < returnedMatches.length) {
+      const patternIndex = returnedMatches[i++];
+      const captures = [];
+
+      while (i < returnedMatches.length && typeof returnedMatches[i] === 'string') {
+        const captureName = returnedMatches[i++];
+        captures.push({
+          name: captureName,
+          node: nodes[nodeIndex++],
+        })
+      }
+
+      if (this.query.predicates[patternIndex].every(p => p(captures))) {
+        const result = {pattern: patternIndex, captures};
+        const setProperties = this.query.setProperties[patternIndex];
+        const assertedProperties = this.query.assertedProperties[patternIndex];
+        const refutedProperties = this.query.refutedProperties[patternIndex];
+        if (setProperties) result.setProperties = setProperties;
+        if (assertedProperties) result.assertedProperties = assertedProperties;
+        if (refutedProperties) result.refutedProperties = refutedProperties;
+        return { value: result };
+      }
+    }
+  }
 }
 
 /*

--- a/src/addon_data.h
+++ b/src/addon_data.h
@@ -40,6 +40,9 @@ public:
 
   // lookaheaditerator
   Napi::FunctionReference lookahead_iterator_constructor;
+
+  // matches_iterator
+  Napi::FunctionReference matches_iterator_constructor;
 };
 
 } // namespace node_tree_sitter

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -5,6 +5,7 @@
 #include "./node.h"
 #include "./parser.h"
 #include "./query.h"
+#include "./matches_iterator.h"
 #include "./tree.h"
 #include "./tree_cursor.h"
 
@@ -24,6 +25,7 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
   LookaheadIterator::Init(env, exports);
   Parser::Init(env, exports);
   Query::Init(env, exports);
+  MatchesIterator::Init(env, exports);
   Tree::Init(env, exports);
   TreeCursor::Init(env, exports);
 

--- a/src/matches_iterator.cc
+++ b/src/matches_iterator.cc
@@ -1,0 +1,137 @@
+#include "matches_iterator.h"
+#include "query.h"
+#include "tree.h"
+#include "node.h"
+
+#include <vector>
+
+using namespace Napi;
+
+namespace node_tree_sitter {
+
+void MatchesIterator::Init(Napi::Env env, Napi::Object exports) {
+  Function ctor = DefineClass(env, "MatchesIterator", {
+    InstanceMethod<&MatchesIterator::Iterator>(Symbol::WellKnown(env, "iterator"), napi_default_method),
+    InstanceMethod<&MatchesIterator::Next>("_next", napi_default_method),
+    InstanceAccessor<&MatchesIterator::GetQuery>("query", static_cast<napi_property_attributes>(napi_enumerable | napi_configurable)),
+    InstanceAccessor<&MatchesIterator::GetTree>("tree", static_cast<napi_property_attributes>(napi_enumerable | napi_configurable)),
+  });
+
+  auto *data = env.GetInstanceData<AddonData>();
+  data->matches_iterator_constructor = Napi::Persistent(ctor);
+  exports["MatchesIterator"] = ctor;
+}
+
+MatchesIterator::MatchesIterator(const Napi::CallbackInfo &info) : Napi::ObjectWrap<MatchesIterator>(info) {
+  Napi::Env env = info.Env();
+
+  const Query *query = Query::UnwrapQuery(info[0]);
+  if (query == nullptr) {
+    throw Error::New(env, "Missing argument query");
+  }
+  query_ = Napi::Persistent(info[0]);
+
+  const Tree *tree = Tree::UnwrapTree(info[1]);
+  if (tree == nullptr) {
+    throw Error::New(env, "Missing argument tree");
+  }
+  tree_ = Napi::Persistent(info[1]);
+
+  uint32_t start_row = 0, start_column = 0, end_row = 0, end_column = 0, start_index = 0, end_index = 0,
+             match_limit = UINT32_MAX, max_start_depth = UINT32_MAX;
+
+  if (info.Length() > 2 && info[2].IsNumber()) {
+    start_row = info[2].As<Number>().Uint32Value();
+  }
+  if (info.Length() > 3 && info[3].IsNumber()) {
+    start_column = info[3].As<Number>().Uint32Value() << 1;
+  }
+  if (info.Length() > 4 && info[4].IsNumber()) {
+    end_row = info[4].As<Number>().Uint32Value();
+  }
+  if (info.Length() > 5 && info[5].IsNumber()) {
+    end_column = info[5].As<Number>().Uint32Value() << 1;
+  }
+  if (info.Length() > 6 && info[6].IsNumber()) {
+    start_index = info[6].As<Number>().Uint32Value();
+  }
+  if (info.Length() > 7 && info[7].IsNumber()) {
+    end_index = info[7].As<Number>().Uint32Value() << 1;
+  }
+  if (info.Length() > 8 && info[8].IsNumber()) {
+    match_limit = info[8].As<Number>().Uint32Value();
+  }
+  if (info.Length() > 9 && info[9].IsNumber()) {
+    max_start_depth = info[9].As<Number>().Uint32Value();
+  }
+
+  query_cursor_ = ts_query_cursor_new();
+  const TSQuery *ts_query = query->get();
+  TSNode root_node = node_methods::UnmarshalNode(env, tree);
+  TSPoint start_point = {start_row, start_column};
+  TSPoint end_point = {end_row, end_column};
+  ts_query_cursor_set_point_range(query_cursor_, start_point, end_point);
+  ts_query_cursor_set_byte_range(query_cursor_, start_index, end_index);
+  ts_query_cursor_set_match_limit(query_cursor_, match_limit);
+  ts_query_cursor_set_max_start_depth(query_cursor_, max_start_depth);
+  ts_query_cursor_exec(query_cursor_, ts_query, root_node);
+}
+
+MatchesIterator::~MatchesIterator() {
+  ts_query_cursor_delete(query_cursor_);
+}
+
+Napi::Value MatchesIterator::Iterator(const Napi::CallbackInfo &info) {
+  return info.This();
+}
+
+Napi::Value MatchesIterator::Next(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  auto result = Object::New(env);
+  const Query *query = Query::UnwrapQuery(query_.Value());
+  const Tree *tree = Tree::UnwrapTree(tree_.Value());
+
+  TSQueryMatch match;
+  if (!ts_query_cursor_next_match(query_cursor_, &match)) {
+    result["done"] = true;
+    return result;
+  }
+
+  Array js_match = Array::New(env);
+  unsigned index = 0;
+  std::vector<TSNode> nodes;
+
+  js_match[index++] = Number::New(env, match.pattern_index);
+
+  for (uint16_t i = 0; i < match.capture_count; i++) {
+    const TSQueryCapture &capture = match.captures[i];
+
+    uint32_t capture_name_len = 0;
+    const char *capture_name = ts_query_capture_name_for_id(
+        query->get(), capture.index, &capture_name_len);
+
+    TSNode node = capture.node;
+    nodes.push_back(node);
+
+    String js_capture = String::New(env, capture_name);;
+    js_match[index++] = js_capture;
+  }
+
+  auto js_nodes = node_methods::GetMarshalNodes(info, tree, nodes.data(), nodes.size());
+
+  auto value = Array::New(env);
+  value[0U] = js_match;
+  value[1] = js_nodes;
+  result["value"] = value;
+  return result;
+}
+
+Napi::Value MatchesIterator::GetQuery(const Napi::CallbackInfo &info) {
+  return query_.Value();
+}
+
+Napi::Value MatchesIterator::GetTree(const Napi::CallbackInfo &info) {
+  return tree_.Value();
+}
+
+} // namespace node_tree_sitter

--- a/src/matches_iterator.h
+++ b/src/matches_iterator.h
@@ -1,0 +1,29 @@
+#ifndef NODE_TREE_SITTER_MATCHES_ITERATOR_H_
+#define NODE_TREE_SITTER_MATCHES_ITERATOR_H_
+
+#include <napi.h>
+#include "tree_sitter/api.h"
+
+namespace node_tree_sitter {
+
+class MatchesIterator final : public Napi::ObjectWrap<MatchesIterator> {
+ public:
+  static void Init(Napi::Env env, Napi::Object exports);
+
+  explicit MatchesIterator(const Napi::CallbackInfo &info);
+  ~MatchesIterator() final;
+
+ private:
+  Napi::Reference<Napi::Value> query_;
+  Napi::Reference<Napi::Value> tree_;
+  TSQueryCursor *query_cursor_ = nullptr;
+
+  Napi::Value Iterator(const Napi::CallbackInfo &info);
+  Napi::Value Next(const Napi::CallbackInfo &info);
+  Napi::Value GetQuery(const Napi::CallbackInfo &info);
+  Napi::Value GetTree(const Napi::CallbackInfo &info);
+};
+
+} // namespace node_tree_sitter
+
+#endif // NODE_TREE_SITTER_MATCHES_ITERATOR_H_

--- a/src/query.cc
+++ b/src/query.cc
@@ -39,6 +39,7 @@ void Query::Init(Napi::Env env, Napi::Object exports) {
     InstanceAccessor("matchLimit", &Query::MatchLimit, nullptr, napi_default_method),
 
     InstanceMethod("_matches", &Query::Matches, napi_default_method),
+    InstanceMethod("_matchesIter", &Query::MatchesIter, napi_default_method),
     InstanceMethod("_captures", &Query::Captures, napi_default_method),
     InstanceMethod("_getPredicates", &Query::GetPredicates, napi_default_method),
     InstanceMethod("disableCapture", &Query::DisableCapture, napi_default_method),
@@ -245,6 +246,17 @@ Napi::Value Query::Matches(const Napi::CallbackInfo &info) {
   result[0U] = js_matches;
   result[1] = js_nodes;
   return result;
+}
+
+Napi::Value Query::MatchesIter(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  auto *data = info.Env().GetInstanceData<AddonData>();
+  size_t argc = info.Length();
+  std::vector<napi_value> args(argc + 1);
+  args[0] = info.This();
+  napi_status status = napi_get_cb_info(env, static_cast<napi_callback_info>(info), &argc, args.data() + 1, nullptr, nullptr);
+  NAPI_THROW_IF_FAILED_VOID(env, status);
+  return data->matches_iterator_constructor.New(args);
 }
 
 Napi::Value Query::Captures(const Napi::CallbackInfo &info) {

--- a/src/query.h
+++ b/src/query.h
@@ -5,7 +5,6 @@
 #include "tree_sitter/api.h"
 
 #include <napi.h>
-#include <node_object_wrap.h>
 
 namespace node_tree_sitter {
 
@@ -17,11 +16,16 @@ class Query final : public Napi::ObjectWrap<Query> {
   explicit Query(const Napi::CallbackInfo &info);
   ~Query() final;
 
+  const TSQuery *get() const {
+    return query_;
+  }
+
  private:
   TSQuery *query_;
 
   Napi::Value New(const Napi::CallbackInfo &);
   Napi::Value Matches(const Napi::CallbackInfo &);
+  Napi::Value MatchesIter(const Napi::CallbackInfo &);
   Napi::Value Captures(const Napi::CallbackInfo &);
   Napi::Value GetPredicates(const Napi::CallbackInfo &);
   Napi::Value DisableCapture(const Napi::CallbackInfo &);

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -109,6 +109,20 @@ describe("Query", () => {
       ]);
     });
 
+    it("returns all of the matches (iterator) for the given query", () => {
+      const tree = parser.parse("function one() { two(); function three() {} }");
+      const query = new Query(JavaScript, `
+        (function_declaration name: (identifier) @fn-def)
+        (call_expression function: (identifier) @fn-ref)
+      `);
+      const matches = [...query.matchesIter(tree.rootNode)];
+      assert.deepEqual(formatMatches(tree, matches), [
+        { pattern: 0, captures: [{ name: "fn-def", text: "one" }] },
+        { pattern: 1, captures: [{ name: "fn-ref", text: "two" }] },
+        { pattern: 0, captures: [{ name: "fn-def", text: "three" }] },
+      ]);
+    });
+
     it("can search in a specified ranges", () => {
       const tree = parser.parse("[a, b,\nc, d,\ne, f,\ng, h]");
       const query = new Query(JavaScript, "(identifier) @element");


### PR DESCRIPTION
Add iterator methods to Query

Still need to do `capturesIter` and `CapturesIterator`.

I'm not that happy about the code duplication though... We could probably implement `matches` and `captures` in terms of `matchesIter` and `capturesIter` to reduce it.

P.S. `LookaheadIterator[@@iterator]` can probably be implemented in C++.

Fixes #178