### PR TITLE
Remove `QueryCapture.text` from typings. It's not really there

### DIFF
--- a/tree-sitter.d.ts
+++ b/tree-sitter.d.ts
@@ -151,7 +151,6 @@ declare module "tree-sitter" {
 
     export interface QueryCapture {
       name: string;
-      text?: string;
       node: SyntaxNode;
       setProperties?: { [prop: string]: string | null };
       assertedProperties?: { [prop: string]: string | null };


### PR DESCRIPTION
Fixes #198