### PR TITLE
Support compiling single-file executables via `bun build --compile`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
-const binding = require('node-gyp-build')(__dirname);
+const binding = typeof process.versions.bun === "string" ?
+    // Statically analyzable enough for `bun build --compile` to embed the tree-sitter.node napi addon
+    require(`./prebuilds/${process.platform}-${process.arch}/tree-sitter.node`) :
+    require('node-gyp-build')(__dirname);
 const {Query, Parser, NodeMethods, Tree, TreeCursor, LookaheadIterator} = binding;
 
 const util = require('util');


### PR DESCRIPTION
This unblocks using `tree-sitter` in [single-file executables](https://bun.sh/docs/bundler/executables)

`node-gyp-build` performs runtime checks for figuring out where the `.node` file is, but those runtime checks are difficult for static analysis to figure out where the `.node` file is. If we can rely on the prebuild to exist, we can use a template string and Bun will inline the `process.platform`, `process.arch`, and `process.versions.bun` fields within `--compile`.



```sh
bun build --compile --format=cjs ./foo.js
```

Where `foo.js` is:
```js
const Parser = require('tree-sitter');
const JavaScript = require('tree-sitter-javascript');

const parser = new Parser();
parser.setLanguage(JavaScript);

const sourceCode = 'let x = 1; console.log(x);';
const tree = parser.parse(sourceCode);

console.log(tree);
```

Related PRs:
- https://github.com/oven-sh/bun/pull/14940
- https://github.com/oven-sh/bun/pull/14935
- https://github.com/oven-sh/bun/pull/14915


