### PR TITLE
Fix helpful "Incompatible language version" error not showing

### DIFF
--- a/src/language.cc
+++ b/src/language.cc
@@ -40,8 +40,7 @@ const TSLanguage *UnwrapLanguage(Napi::Value value) {
           std::to_string(TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION) + " - " +
           std::to_string(TREE_SITTER_LANGUAGE_VERSION) + ". Got: " +
           std::to_string(ts_language_version(language));
-        RangeError::New(env, message.c_str());
-        return nullptr;
+        throw RangeError::New(env, message.c_str());
       }
       return language;
     }


### PR DESCRIPTION
When using `parser.setLanguage(myLang)`, the `UnwrapLanguage` function checks that the ABI version is compatible.

If the language is not compatible, an error like this is created:

```
RangeError: Incompatible language version. Compatible range: 13 - 14. Got: 15`
    at Parser.setLanguage
```

Due to a [refactoring](https://github.com/tree-sitter/node-tree-sitter/commit/98a68e40da6cba0edfd89e6d2efe6d081e264b02#diff-97ca194f7139bbd17217701a94291f14e3be03bfb1568f1a2bad3cdbeaa3fa01R34) of the exceptions, this `RangeError` is created but not thrown. The `UnwrapLanguage` function returns a null pointer instead.

This leads to cryptic errors elsewhere, such as:
```
TypeError: Cannot read properties of undefined (reading 'length')
    at initializeLanguageNodeClasses
    at Parser.setLanguage
```

This is resulting in issues being raised in other repos, such as https://github.com/tree-sitter/tree-sitter/issues/4234.