### PR TITLE
Define `type` property on `SyntaxNode` subclasses with `defineProperty`

### DIFF
--- a/index.js
+++ b/index.js
@@ -894,7 +894,10 @@ function initializeLanguageNodeClasses(language) {
 
     const className = camelCase(typeName, true) + 'Node';
     const nodeSubclass = eval(`class ${className} extends SyntaxNode {${classBody}}; ${className}`);
-    nodeSubclass.prototype.type = typeName;
+    Object.defineProperty(nodeSubclass.prototype, 'type', {
+        value: typeName,
+        enumerable: true,
+    });
     nodeSubclass.prototype.fields = Object.freeze(fieldNames.sort())
     nodeSubclasses[id] = nodeSubclass;
   }


### PR DESCRIPTION
Since `SyntaxNode` defines `type` as an accessor property, the write to `nodeSubclass.prototype.type` is silently swallowed.
We can work around this by defining the type with `Object.defineProperty`.
