### PR TITLE
ci(publish): unset NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
         run: npm install
 
       - name: Publish to NPM
-        run: npm publish
+        run: unset NODE_AUTH_TOKEN ; npm publish
 
       - name: Prepare release artifacts
         run: |


### PR DESCRIPTION
Hopefully this will stop GitHub from being dumb.